### PR TITLE
Silent imports, optional stdio Rich UI, Vercel functions path fix, and remove noisy debug print

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ uv run python server.py
 
 You can also use the [FastMCP CLI](https://gofastmcp.com/) when `fastmcp.json` is present: run `fastmcp run` or `fastmcp run fastmcp.json` to start the server using the config file (CLI options override the config). For the full local CLI with options like `--list-tools`, use `python server.py` instead.
 
-The server uses stdio by default. For HTTP:
+The server uses stdio by default and keeps stdout reserved for MCP JSON-RPC traffic. Human-readable Rich output is suppressed in stdio mode unless you explicitly enable it with `UML_MCP_STDIO_UI=true`. For HTTP:
 
 ```bash
 python server.py --transport http --host 127.0.0.1 --port 8000
@@ -111,6 +111,12 @@ List available tools and exit:
 
 ```bash
 python server.py --list-tools
+```
+
+To show the Rich banner/tables while still using stdio, send that UI to stderr explicitly:
+
+```bash
+UML_MCP_STDIO_UI=true python server.py --list-tools
 ```
 
 ### Deploy to Vercel and publish on Smithery

--- a/api/app.py
+++ b/api/app.py
@@ -1,6 +1,8 @@
 """
-Vercel serverless entrypoint: loads the root FastAPI app so the pattern
-"app.py" in vercel.json functions matches a file inside the api/ directory.
+Vercel serverless entrypoint for ``api/app.py``.
+
+This module loads the root FastAPI app so Vercel's ``functions`` configuration
+can target the actual serverless file inside the ``api/`` directory.
 """
 import importlib.util
 import os

--- a/api/app.py
+++ b/api/app.py
@@ -4,6 +4,7 @@ Vercel serverless entrypoint for ``api/app.py``.
 This module loads the root FastAPI app so Vercel's ``functions`` configuration
 can target the actual serverless file inside the ``api/`` directory.
 """
+
 import importlib.util
 import os
 

--- a/docs/integrations/vercel_smithery.md
+++ b/docs/integrations/vercel_smithery.md
@@ -154,7 +154,7 @@ MCP Streamable HTTP keeps a **long-lived GET** connection open (Server-Sent Even
 **Mitigations:**
 
 1. **Increase max duration (Pro/Enterprise)**  
-   This repo sets `maxDuration: 800` in `vercel.json` for `app.py`. On **Pro** or **Enterprise** (with Fluid Compute), that allows the GET `/mcp` connection to stay open up to **800 seconds** (~13 minutes) instead of 300. On **Hobby**, the platform cap is 300s, so the setting has no effect beyond the default.
+   This repo sets `maxDuration: 200` in `vercel.json` for `api/app.py`, which is the Vercel serverless entrypoint. On **Pro** or **Enterprise** (with Fluid Compute), you can raise that value further if you need longer-lived `/mcp` sessions. On **Hobby**, the platform cap is still 300s, so long-lived MCP streams will eventually time out regardless.
 
 2. **Reconnect on timeout**  
    Clients should reconnect when the stream ends. Cursor and Smithery typically retry or allow re-adding the server; after a timeout, reconnect to `/mcp` to start a new session.

--- a/mcp_core/core/cli.py
+++ b/mcp_core/core/cli.py
@@ -13,7 +13,7 @@ from rich.logging import RichHandler
 from rich.panel import Panel
 from rich.table import Table
 
-console = Console()
+console = Console(file=sys.stderr)
 
 
 def parse_args():
@@ -56,7 +56,7 @@ def setup_logging(debug=False):
         logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
     )
 
-    console_handler = RichHandler(rich_tracebacks=True)
+    console_handler = RichHandler(console=console, rich_tracebacks=True)
     console_handler.setLevel(level)
 
     logging.basicConfig(
@@ -79,8 +79,19 @@ def safe_import(module_name, display_name=None):
         return __import__(module_name)
     except ImportError as e:
         display_name = display_name or module_name
+        logging.getLogger(__name__).error("Error importing %s: %s", display_name, e)
         console.print(f"[bold red]Error importing {display_name}:[/bold red] {str(e)}")
         return None
+
+
+def _stdio_ui_enabled():
+    """Return True when human-readable stderr UI is explicitly enabled for stdio."""
+    return os.environ.get("UML_MCP_STDIO_UI", "").lower() in ("1", "true", "yes")
+
+
+def _should_render_human_output(args):
+    """Show Rich UI only for non-stdio transports unless explicitly enabled."""
+    return args.transport != "stdio" or _stdio_ui_enabled()
 
 
 def _display_tools_fallback(mcp_settings, tools_table):
@@ -259,27 +270,31 @@ def run():
 
         get_mcp_server()
 
-        console.print(
-            Panel(f"[bold green]UML-MCP Server v{MCP_SETTINGS.version}[/bold green]")
-        )
-        table = Table(title="Server Configuration")
-        table.add_column("Setting", style="cyan")
-        table.add_column("Value", style="green")
-        table.add_row("Server Name", MCP_SETTINGS.server_name)
-        table.add_row("Transport", args.transport)
-        table.add_row("Available Tools", str(len(MCP_SETTINGS.tools)))
-        table.add_row("Available Prompts", str(len(MCP_SETTINGS.prompts)))
-        table.add_row("Available Resources", str(len(MCP_SETTINGS.resources)))
-        if args.transport == "http":
-            table.add_row("Host", args.host)
-            table.add_row("Port", str(args.port))
-        console.print(table)
+        show_human_output = _should_render_human_output(args)
+
+        if show_human_output:
+            console.print(
+                Panel(f"[bold green]UML-MCP Server v{MCP_SETTINGS.version}[/bold green]")
+            )
+            table = Table(title="Server Configuration")
+            table.add_column("Setting", style="cyan")
+            table.add_column("Value", style="green")
+            table.add_row("Server Name", MCP_SETTINGS.server_name)
+            table.add_row("Transport", args.transport)
+            table.add_row("Available Tools", str(len(MCP_SETTINGS.tools)))
+            table.add_row("Available Prompts", str(len(MCP_SETTINGS.prompts)))
+            table.add_row("Available Resources", str(len(MCP_SETTINGS.resources)))
+            if args.transport == "http":
+                table.add_row("Host", args.host)
+                table.add_row("Port", str(args.port))
+            console.print(table)
 
         list_tools = (
             args.list_tools or os.environ.get("LIST_TOOLS", "").lower() == "true"
         )
         if list_tools:
-            display_tools_and_resources(MCP_SETTINGS)
+            if show_human_output:
+                display_tools_and_resources(MCP_SETTINGS)
             return
 
         start_server(transport=args.transport, host=args.host, port=args.port)

--- a/mcp_core/core/cli.py
+++ b/mcp_core/core/cli.py
@@ -274,7 +274,9 @@ def run():
 
         if show_human_output:
             console.print(
-                Panel(f"[bold green]UML-MCP Server v{MCP_SETTINGS.version}[/bold green]")
+                Panel(
+                    f"[bold green]UML-MCP Server v{MCP_SETTINGS.version}[/bold green]"
+                )
             )
             table = Table(title="Server Configuration")
             table.add_column("Setting", style="cyan")

--- a/server.py
+++ b/server.py
@@ -21,5 +21,6 @@ def __getattr__(name):
         return get_mcp_server()
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
+
 if __name__ == "__main__":
     main()

--- a/server.py
+++ b/server.py
@@ -5,12 +5,21 @@ Canonical MCP server entry point for UML diagram generation.
 Uses mcp_core (tools, config, Kroki) for consistent diagram generation.
 Run with: python server.py [--transport stdio|http] [--host 127.0.0.1] [--port 8000]
 Or with FastMCP CLI: fastmcp run server.py / fastmcp run fastmcp.json
+
+The `mcp` export is resolved lazily so importing this module stays silent on
+stdout until the server is explicitly requested.
 """
 
 from mcp_core.core.server import get_mcp_server, main
 
-# Expose for FastMCP CLI (fastmcp run server.py / fastmcp run fastmcp.json)
-mcp = get_mcp_server()
+__all__ = ["get_mcp_server", "main"]
+
+
+def __getattr__(name):
+    """Resolve the FastMCP export lazily to avoid import-time side effects."""
+    if name == "mcp":
+        return get_mcp_server()
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 if __name__ == "__main__":
     main()

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -260,8 +260,12 @@ def test_vercel_functions_patterns_target_existing_api_files():
 
     assert "api/app.py" in function_patterns
     for pattern in function_patterns:
-        assert pattern.startswith("api/"), f"Function pattern must be under api/: {pattern}"
-        assert (repo_root / pattern).is_file(), f"Missing Vercel function file: {pattern}"
+        assert pattern.startswith("api/"), (
+            f"Function pattern must be under api/: {pattern}"
+        )
+        assert (repo_root / pattern).is_file(), (
+            f"Missing Vercel function file: {pattern}"
+        )
 
 
 def test_vercel_rewrites_still_target_api_app():

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -4,6 +4,7 @@ Tests for the FastAPI application.
 
 import json
 import os
+from pathlib import Path
 from unittest.mock import MagicMock, mock_open, patch
 
 import pytest
@@ -249,3 +250,27 @@ def test_kroki_encode_unsupported_format():
     data = response.json()
     assert "detail" in data
     assert "Format" in data["detail"] or "not supported" in data["detail"].lower()
+
+
+def test_vercel_functions_patterns_target_existing_api_files():
+    """vercel.json function patterns should point to real files under api/."""
+    repo_root = Path(__file__).resolve().parents[1]
+    vercel_config = json.loads((repo_root / "vercel.json").read_text())
+    function_patterns = vercel_config.get("functions", {})
+
+    assert "api/app.py" in function_patterns
+    for pattern in function_patterns:
+        assert pattern.startswith("api/"), f"Function pattern must be under api/: {pattern}"
+        assert (repo_root / pattern).is_file(), f"Missing Vercel function file: {pattern}"
+
+
+def test_vercel_rewrites_still_target_api_app():
+    """Vercel rewrites should continue routing app traffic to /api/app."""
+    repo_root = Path(__file__).resolve().parents[1]
+    vercel_config = json.loads((repo_root / "vercel.json").read_text())
+    rewrites = vercel_config.get("rewrites", [])
+
+    rewrite_map = {rewrite["source"]: rewrite["destination"] for rewrite in rewrites}
+    assert rewrite_map["/mcp"] == "/api/app"
+    assert rewrite_map["/mcp/(.*)"] == "/api/app"
+    assert rewrite_map["/(.*)"] == "/api/app"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -123,8 +123,9 @@ class TestSafeImport:
 
     def test_nonexistent_module_returns_none(self):
         """safe_import of nonexistent module returns None."""
-        with patch.object(cli.console, "print"), patch.object(
-            logging.getLogger("mcp_core.core.cli"), "error"
+        with (
+            patch.object(cli.console, "print"),
+            patch.object(logging.getLogger("mcp_core.core.cli"), "error"),
         ):
             result = cli.safe_import("_nonexistent_module_xyz_123")
         assert result is None

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,6 +3,7 @@ Tests for mcp_core.core.cli.
 """
 
 import logging
+import os
 import sys
 from unittest.mock import MagicMock, patch
 
@@ -122,7 +123,9 @@ class TestSafeImport:
 
     def test_nonexistent_module_returns_none(self):
         """safe_import of nonexistent module returns None."""
-        with patch.object(cli.console, "print"):
+        with patch.object(cli.console, "print"), patch.object(
+            logging.getLogger("mcp_core.core.cli"), "error"
+        ):
             result = cli.safe_import("_nonexistent_module_xyz_123")
         assert result is None
 
@@ -243,3 +246,78 @@ class TestRun:
         start_server_mock.assert_called_once_with(
             transport="http", host="0.0.0.0", port=9999
         )
+
+    @patch("mcp_core.core.server.start_server")
+    @patch("mcp_core.core.server.get_mcp_server")
+    @patch(
+        "mcp_core.core.config.MCP_SETTINGS",
+        MagicMock(
+            version="1.0",
+            server_name="Test",
+            tools=[],
+            prompts=[],
+            resources=[],
+        ),
+    )
+    @patch("mcp_core.core.cli.safe_import", return_value=MagicMock())
+    @patch("mcp_core.core.cli.setup_logging", return_value=MagicMock())
+    @patch("mcp_core.core.cli.parse_args")
+    def test_run_stdio_skips_human_output_by_default(
+        self,
+        parse_mock,
+        setup_mock,
+        safe_import_mock,
+        get_server_mock,
+        start_server_mock,
+    ):
+        """run() with stdio transport does not emit Rich console output by default."""
+        parse_mock.return_value = MagicMock(
+            debug=False,
+            transport="stdio",
+            host="127.0.0.1",
+            port=8000,
+            list_tools=False,
+        )
+        with patch.object(cli.console, "print") as print_mock:
+            cli.run()
+        print_mock.assert_not_called()
+        start_server_mock.assert_called_once_with(
+            transport="stdio", host="127.0.0.1", port=8000
+        )
+
+    @patch("mcp_core.core.server.start_server")
+    @patch("mcp_core.core.server.get_mcp_server")
+    @patch(
+        "mcp_core.core.config.MCP_SETTINGS",
+        MagicMock(
+            version="1.0",
+            server_name="Test",
+            tools=["generate_uml"],
+            prompts=["uml_diagram"],
+            resources=["uml://types"],
+        ),
+    )
+    @patch("mcp_core.core.cli.safe_import", return_value=MagicMock())
+    @patch("mcp_core.core.cli.setup_logging", return_value=MagicMock())
+    @patch("mcp_core.core.cli.parse_args")
+    def test_run_stdio_can_render_human_output_when_explicitly_enabled(
+        self,
+        parse_mock,
+        setup_mock,
+        safe_import_mock,
+        get_server_mock,
+        start_server_mock,
+    ):
+        """run() can render stderr UI in stdio mode only when explicitly enabled."""
+        parse_mock.return_value = MagicMock(
+            debug=False,
+            transport="stdio",
+            host="127.0.0.1",
+            port=8000,
+            list_tools=True,
+        )
+        with patch.dict(os.environ, {"UML_MCP_STDIO_UI": "true"}, clear=False):
+            with patch.object(cli.console, "print") as print_mock:
+                cli.run()
+        assert print_mock.call_count >= 4
+        start_server_mock.assert_not_called()

--- a/tests/test_server_bootstrap.py
+++ b/tests/test_server_bootstrap.py
@@ -111,7 +111,9 @@ class TestServerBootstrap:
     ):
         """Importing server.py should not write anything to stdout."""
         server_path = Path(__file__).resolve().parents[1] / "server.py"
-        spec = importlib.util.spec_from_file_location("isolated_server_module", server_path)
+        spec = importlib.util.spec_from_file_location(
+            "isolated_server_module", server_path
+        )
         module = importlib.util.module_from_spec(spec)
 
         stdout = StringIO()

--- a/tests/test_server_bootstrap.py
+++ b/tests/test_server_bootstrap.py
@@ -5,7 +5,11 @@ When pytest runs, the FastMCP wrapper uses the mock implementation (pytest in sy
 so create_mcp_server() returns a mock server with _tools, _prompts, _resources populated.
 """
 
+import contextlib
+import importlib.util
 import os
+from io import StringIO
+from pathlib import Path
 
 import pytest
 
@@ -101,3 +105,19 @@ class TestServerBootstrap:
         server = create_mcp_server()
         for name, func in server._prompts.items():
             assert callable(func), f"Prompt {name} handler should be callable"
+
+    def test_importing_server_module_keeps_stdout_silent(
+        self, reset_mcp_server_singleton
+    ):
+        """Importing server.py should not write anything to stdout."""
+        server_path = Path(__file__).resolve().parents[1] / "server.py"
+        spec = importlib.util.spec_from_file_location("isolated_server_module", server_path)
+        module = importlib.util.module_from_spec(spec)
+
+        stdout = StringIO()
+        stderr = StringIO()
+        with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+            spec.loader.exec_module(module)
+
+        assert stdout.getvalue() == ""
+        assert hasattr(module, "__getattr__")

--- a/tools/kroki/d2.py
+++ b/tools/kroki/d2.py
@@ -81,8 +81,6 @@ for keyword in sorted(reserved_keywords):
 
 # -><--<->3danimatedboldborder-radiusbottomclassclassesconstraintdescdirectiondouble-borderfillfill-patternfilledfontfont-colorfont-sizegrid-columnsgrid-gapgrid-rowsheighthorizontal-gapiconitaliclabellayersleftlinevarslinkmultiplenearopacityrightscenariosshadowshapesource-arrowheadstepsstrokestroke-dashstroke-widthstyletarget-arrowheadtext-transformtooltiptopunderlinevertical-gapwidth
 
-print("Compression dictionary:", compression_dict)
-
 compression_dict = "-><---<->3danimatedboldborder-radiusclassclassesconstraintdescdirectiondouble-borderfillfill-patternfilledfontfont-colorfont-sizegrid-columnsgrid-gapgrid-rowsheighthorizontal-gapiconitaliclabellayersleftlinkmultiplenearopacityscenariosshadowshapesource-arrowheadstepsstrokestroke-dashstroke-widthstyletarget-arrowheadtext-transformtooltiptopunderlinevarsvertical-gapwidth"
 
 

--- a/vercel.json
+++ b/vercel.json
@@ -4,7 +4,7 @@
   "installCommand": "pip install --upgrade pip",
   "framework": null,
   "functions": {
-    "app.py": {
+    "api/app.py": {
       "maxDuration": 200
     }
   },


### PR DESCRIPTION
### Motivation
- Prevent server import side-effects writing to stdout and avoid noisy debug output during normal imports. 
- Make the Rich/stderr human UI conditional so `stdio` transport remains machine-friendly unless explicitly enabled. 
- Ensure Vercel configuration points to actual files under `api/` so serverless functions and rewrites resolve correctly. 

### Description
- Update `server.py` to lazily export the `mcp` symbol via `__getattr__` and add `__all__` so importing the module doesn't produce stdout side-effects. 
- Change `mcp_core/core/cli.py` to send the `rich` `Console` to `RichHandler` using `console=sys.stderr`, add logging on import failures in `safe_import`, and add `UML_MCP_STDIO_UI` support with helper functions ` _stdio_ui_enabled` and `_should_render_human_output` to conditionally render Rich UI and tool listings for `stdio` transport. 
- Quiet the kroki D2 tool by removing a leftover `print` that emitted the compression dictionary in `tools/kroki/d2.py`. 
- Adjust the Vercel config at `vercel.json` to register `api/app.py` under `functions`, and make `api/app.py` documentation clearer about how it loads the root FastAPI app. 
- Add/modify tests to assert the new behaviors, including `tests/test_app.py` checks for `vercel.json` function/rewrite targets, `tests/test_cli.py` cases for conditional stdio UI rendering, and `tests/test_server_bootstrap.py` to ensure importing `server.py` remains silent. 

### Testing
- Ran the test suite with `pytest` covering `tests/test_cli.py`, `tests/test_app.py`, and `tests/test_server_bootstrap.py`. All tests executed and passed. 
- Verified the new CLI unit tests for `stdio` vs `http` behavior and the `UML_MCP_STDIO_UI` env var exercised the conditional Rich UI path. 
- Verified the import-time silence test by importing `server.py` in an isolated module context and asserting no stdout output and presence of `__getattr__`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd955e20bc832baaeacf6bf9b7b3d8)