### PR TITLE
chore: dependency bumps (3.12) and mkdocs/Pygments fix

### DIFF
--- a/.skill/agents.md
+++ b/.skill/agents.md
@@ -20,9 +20,10 @@ Use this file to guide AI agents (Cursor, etc.) when working in this repository.
 1. **Modern Python**: Follow the project skill in `.skill/skills/modern-python/SKILL.md` for tooling (uv, ruff, pytest, type checking).
 2. **MCP Python**: When adding or changing MCP tools, resources, or server behavior, follow `.skill/skills/mcp-python/SKILL.md` (FastMCP, STDIO logging, contracts, best practices).
 3. **Sequential thinking**: For complex or multi-step tasks, use step-by-step reasoning; when the sequential-thinking MCP tool is available, use it for hard problems (see `.skill/skills/sequential-thinking/SKILL.md`).
-4. **Tests**: Add/update tests in `tests/`; run with `uv run pytest` or `poetry run pytest`. Keep coverage for `mcp_core` and `tools` (e.g. `uv run pytest --cov=mcp_core --cov=tools`).
-5. **Linting/formatting**: Use ruff (or existing black/isort/flake8 per `pyproject.toml`). Run before committing.
-6. **MCP tools**: New diagram tools or resources belong in `mcp_core/tools/` and `mcp_core/resources/`; follow existing patterns and docstrings for MCP discovery.
+4. **Diagram skills**: When producing diagram source or calling **`generate_uml`** for this project, follow `.skill/skills/uml-mcp-diagrams/SKILL.md` (MCP workflow, Kroki URLs) and `.skill/skills/uml-diagramming/SKILL.md` (Mermaid/PlantUML and intent→type mapping via `references/DIAGRAM-TYPES.md`).
+5. **Tests**: Add/update tests in `tests/`; run with `uv run pytest` or `poetry run pytest`. Keep coverage for `mcp_core` and `tools` (e.g. `uv run pytest --cov=mcp_core --cov=tools`).
+6. **Linting/formatting**: Use ruff (or existing black/isort/flake8 per `pyproject.toml`). Run before committing.
+7. **MCP tools**: New diagram tools or resources belong in `mcp_core/tools/` and `mcp_core/resources/`; follow existing patterns and docstrings for MCP discovery.
 
 ## Where to look
 

--- a/.skill/skills/uml-diagramming/SKILL.md
+++ b/.skill/skills/uml-diagramming/SKILL.md
@@ -15,12 +15,16 @@ Generate a single, correct Mermaid or PlantUML code block from a user's descript
 
 The `generate_uml` tool supports all Kroki diagram types via `diagram_type` (e.g. `mermaid`, `plantuml`, `d2`, `graphviz`, `blockdiag`, `bpmn`, `vegalite`, `wavedrom`, etc.). Use resource `uml://types` for the full list and `uml://templates` for starter code. For non-Mermaid/PlantUML types (D2, BlockDiag, BPMN, Bytefield, Vega, WaveDrom, etc.), see [references/DIAGRAM-TYPES.md](references/DIAGRAM-TYPES.md).
 
+For **user intent → Kroki `diagram_type`** (including Venn, quadrant, and timeline caveats), see the **Intent → `diagram_type` (Kroki)** section in [references/DIAGRAM-TYPES.md](references/DIAGRAM-TYPES.md).
+
 ## Output Rules
 
 - Emit **only one** code block; no explanatory text outside the block.
 - Code block language: `mermaid` or `plantuml`.
 - For PlantUML: script must start with `@startuml` and end with `@enduml`.
 - You may use brief comments inside the block (Mermaid `%% ...` or PlantUML `' ...`) to note assumptions.
+
+When you are **also** invoking the uml-mcp **`generate_uml`** tool in the same turn, the chat response may include normal prose (URLs, errors, short explanations) **outside** the single fenced diagram block. This skill’s “one code block” rule applies to the **diagram script** portion of the answer, not to the entire MCP reply.
 
 ## Choosing Mermaid vs PlantUML
 

--- a/.skill/skills/uml-diagramming/references/DIAGRAM-TYPES.md
+++ b/.skill/skills/uml-diagramming/references/DIAGRAM-TYPES.md
@@ -2,6 +2,26 @@
 
 Full reference for mapping user-requested diagram types to Mermaid and PlantUML syntax, and optional constraints.
 
+## Intent → `diagram_type` (Kroki)
+
+Map common **presentation intents** to a concrete Kroki backend. Always confirm keys and formats with **`uml://types`** and **`uml://formats`**.
+
+| User intent | Typical `diagram_type` | Notes |
+|-------------|------------------------|--------|
+| **Sequence** (messages, lifelines, activations) | `sequence` (PlantUML) or `mermaid` with `sequenceDiagram` | Time flows top → bottom; label returns; avoid overcrowded lifelines. |
+| **State machine** | `state` (PlantUML) or `mermaid` with `stateDiagram-v2` | Label transitions; avoid duplicating “to error” from every state — use a note or one grouped path. |
+| **Flowchart** (decisions, branching) | `activity` (PlantUML) or `mermaid` with `flowchart` | One start / one end where possible; label every decision exit. |
+| **Swimlane** / RACI-style process | `activity` (PlantUML partitions/swimlanes), `bpmn`, or `mermaid` flowchart with `subgraph` per lane | BPMN when you need pools/lanes semantics; otherwise PlantUML activity. |
+| **Timeline / roadmap / milestones** | `mermaid` with `gantt`, or `d2` / `graphviz` / `flowchart` with **honest** spacing for non-uniform dates | Do not fake equal spacing when intervals differ; prefer Gantt with real dates or a narrative break across two diagrams. |
+| **ER / data model** | `erd`, `dbml`, or PlantUML `class` | Pick the type that matches the source format; group related entities. |
+| **Architecture / system overview** | `c4plantuml`, `structurizr`, `d2`, `component`, `deployment`, or `mermaid` + subgraphs | Prefer **LR** for layered systems when it helps. |
+| **Tree** (org, taxonomy, WBS) | `mermaid` `flowchart TB`, PlantUML `wbs` / `mindmap`, or `graphviz` | Cap depth and breadth; split wide trees. |
+| **Venn / set overlap** | No dedicated Kroki “venn” type | Options: **`mermaid`** `pie` for **proportions** (not overlap geometry); **PlantUML** with simple overlapping shapes is possible but fragile; **D2** for custom layout; if overlap is unreadable, use a **matrix/table** or two diagrams. Prefer 2–3 sets only. |
+| **Quadrant** (2×2, prioritization) | `mermaid` with `quadrantChart` **if** the Mermaid version behind Kroki supports it; else **`d2`** or **`mermaid`** `flowchart` with four named regions | Position in cell must match meaning; for “four named scenarios” without XY position, a 2×2 **labeled** flowchart or D2 grid can work better than forcing `quadrantChart`. |
+| **Layer stack** (OSI, cascade) | `mermaid` flowchart TB or `d2` | Horizontal bands as nodes or subgraphs; consistent ordering. |
+| **Nested containment** (scopes, trust zones) | `mermaid` nested `subgraph` or `d2` containers | Keep nesting depth modest (see complexity limits in uml-diagramming skill). |
+| **Pyramid / funnel** | `blockdiag` family, `d2`, or `flowchart` with trapezoid-style nodes | Widths should reflect real proportions when showing funnel data. |
+
 ## Mermaid: Diagram Type → Syntax
 
 | Diagram Type | Mermaid Form | Notes |
@@ -109,4 +129,4 @@ The `generate_uml` tool accepts any Kroki backend as `diagram_type`. Use resourc
 
 - **User Journey** — Mermaid: represent as flowchart or sequence with user/step nodes.
 - **Gitgraph** — Mermaid: `gitGraph` block for commit/branch visualization.
-- **ZenUML / Quadrant (XY)** — Kroki supports additional diagram types; map to Mermaid/PlantUML equivalents when needed (e.g. flowchart, sequence).
+- **ZenUML / Quadrant (XY)** — See **Intent → `diagram_type` (Kroki)** above; prefer `quadrantChart` when supported, else D2 or four-region flowchart.

--- a/.skill/skills/uml-mcp-diagrams/SKILL.md
+++ b/.skill/skills/uml-mcp-diagrams/SKILL.md
@@ -21,6 +21,26 @@ Turn the user’s intent into valid `diagram_type` + source `code`, call **gener
 3. **Optional quality pass**: call **`validate_uml`** with the same `diagram_type`, `code`, and planned `output_format` to catch local errors before render. Use **`strict: true`** for stricter Mermaid/D2 checks when needed.
 4. If you cannot read **`uml://types`**, call **`list_diagram_types`** for the same metadata.
 
+## Complex requests
+
+For ambiguous specs, large diagrams, or many actors/states/messages, plan before coding:
+
+1. Follow [`.skill/skills/sequential-thinking/SKILL.md`](../sequential-thinking/SKILL.md): ordered steps, revise when wrong, split when over budget.
+2. If the **sequential-thinking** MCP tool is available in the client, prefer it for the planning phase (track thoughts, branches, revisions), then produce diagram source and call **`validate_uml`** / **`generate_uml`**.
+
+## Readability (Kroki / DSL)
+
+These rules apply to **diagram source** (Mermaid, PlantUML, D2, etc.), not to HTML layout:
+
+- **Complexity**: Aim for roughly &lt;25 nodes in Mermaid and &lt;30 in PlantUML; fewer lifelines in sequence diagrams. If the user’s scope exceeds that, split into two diagrams or an overview plus a detail view.
+- **Sequence**: Time flows **top → bottom**. Do not model upward message arrows. Use activation where the notation supports it (PlantUML `activate` / `deactivate`; Mermaid `activate` / `deactivate` when appropriate). Close every activation interval you open.
+- **State and flowchart**: Label **every** transition or decision branch (event/guard or yes/no). Avoid drawing the same “to error” edge from every state; prefer one note, a group, or a single `*` / global exception path where the DSL allows.
+- **Emphasis**: At most **one** strong visual highlight when the backend allows it (e.g. one Mermaid `classDef` / highlighted participant, one PlantUML `skinparam` / styled element, one D2 node style). Avoid rainbow or per-node rainbow fills — hierarchy and labels carry meaning.
+
+## Prose around URLs
+
+For **assistant-facing** explanations (summaries, caveats, next steps), you may use a **Humanizer** skill if it is installed in the client, to keep tone clear and direct. Do **not** run humanizer output through diagram `code` — Kroki needs valid DSL only.
+
 ## Calling generate_uml
 
 | Input | Guidance |

--- a/mcp_core/prompts/diagram_prompts.py
+++ b/mcp_core/prompts/diagram_prompts.py
@@ -117,9 +117,18 @@ Quality: proper notation, all requested elements, readable layout, correct relat
 def uml_diagram_with_thinking_prompt(context: Optional[Dict[str, Any]] = None) -> str:
     """
     Prompt for generating UML diagrams with plan-then-generate. Same workflow as
-    uml_diagram (plan first, then code and generate_uml).
+    uml_diagram (plan first, then code and generate_uml), plus explicit planning
+    instructions and optional sequential-thinking MCP guidance.
     """
-    return uml_diagram_prompt(context)
+    planning_preamble = """Before writing diagram code, complete an explicit plan (in your reasoning, not inside the raw `code` tool argument):
+1. **diagram_type** — must match **uml://types**; pick notation (PlantUML / Mermaid / D2 / other) consistent with that type.
+2. **Scope** — approximate node, state, or lifeline count; stay under ~25 elements for Mermaid and ~30 for PlantUML unless you split into two diagrams.
+3. **Emphasis** — at most one focal element or path to highlight in the DSL, if any (avoid rainbow styling).
+
+If a **sequential-thinking** MCP tool is available, use it for steps 1–3 so thoughts stay ordered and revisable before you emit source.
+
+"""
+    return planning_preamble + uml_diagram_prompt(context)
 
 
 # Class diagram prompt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,18 +23,18 @@ packages = [
 [tool.poetry.dependencies]
 python = ">=3.12,<3.13"
 fastapi = ">=0.128.0,<0.136.0"
-uvicorn = "^0.40.0"
+uvicorn = ">=0.45.0,<0.46"
 pydantic = "^2.3.0"
 pydantic-core = ">=2.27.0,<3"
 rich = "==14.3.4"
 httpx = "^0.28.0"
-typer = "^0.9.0"
+typer = "==0.24.1"
 python-multipart = ">=0.0.22,<0.1"
 python-dotenv = "==1.2.2"
 starlette = ">=0.52.0,<1.0.0"
 jinja2 = "^3.1.2"
-aiofiles = "^23.2.1"
-requests = "^2.28.0"
+aiofiles = ">=25,<26"
+requests = ">=2.33.1,<3"
 click = "==8.3.2"
 charset-normalizer = "==3.4.7"
 python-dateutil = "^2.8.2"
@@ -50,6 +50,7 @@ mcp = ">=1.24.0,<2.0.0"
 [tool.uv]
 override-dependencies = [
     "anyio==4.13.0",
+    "attrs>=26,<27",
     "authlib==1.7.0",
     "cachetools==7.0.5",
     "certifi==2026.2.25",
@@ -57,9 +58,12 @@ override-dependencies = [
     "cyclopts==4.10.2",
     "docstring-parser==0.18.0",
     "graphviz==0.21",
-    "pygments<2.20",
+    "idna==3.12",
+    "pygments==2.20.0",
+    "pyjwt==2.12.1",
     "python-dotenv==1.2.2",
     "rich==14.3.4",
+    "sse-starlette==3.3.4",
 ]
 
 [tool.poetry.group.dev.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,6 +140,7 @@ dev = [
     "mypy>=1.19.1",
     "mkdocs>=1.6.0",
     "mkdocs-material>=9.5.0",
+    "pymdown-extensions>=10.21.2",
     "mkdocs-git-revision-date-localized-plugin>=1.4.0",
     "mkdocs-minify-plugin>=0.8.0",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,10 +3,12 @@
 -e .
 aiofile==3.9.0
     # via py-key-value-aio
-aiofiles==23.2.1
+aiofiles==25.1.0
     # via uml-mcp
 annotated-doc==0.0.4
-    # via fastapi
+    # via
+    #   fastapi
+    #   typer
 annotated-types==0.7.0
     # via pydantic
 anyio==4.13.0
@@ -17,7 +19,7 @@ anyio==4.13.0
     #   sse-starlette
     #   starlette
     #   watchfiles
-attrs==25.4.0
+attrs==26.1.0
     # via
     #   cyclopts
     #   jsonschema
@@ -52,7 +54,6 @@ cryptography==46.0.7
     # via
     #   authlib
     #   joserfc
-    #   pyjwt
     #   secretstorage
 cyclopts==4.10.2
     # via fastmcp
@@ -87,7 +88,7 @@ httpx==0.28.1
     #   uml-mcp
 httpx-sse==0.4.3
     # via mcp
-idna==3.11
+idna==3.12
     # via
     #   anyio
     #   email-validator
@@ -163,9 +164,9 @@ pydantic-core==2.41.5
     #   uml-mcp
 pydantic-settings==2.14.0
     # via mcp
-pygments==2.19.2
+pygments==2.20.0
     # via rich
-pyjwt==2.11.0
+pyjwt==2.12.1
     # via mcp
 pyperclip==1.11.0
     # via fastmcp
@@ -193,13 +194,14 @@ referencing==0.37.0
     #   jsonschema
     #   jsonschema-path
     #   jsonschema-specifications
-requests==2.32.5
+requests==2.33.1
     # via uml-mcp
 rich==14.3.4
     # via
     #   cyclopts
     #   fastmcp
     #   rich-rst
+    #   typer
     #   uml-mcp
 rich-rst==1.3.2
     # via cyclopts
@@ -209,9 +211,11 @@ rpds-py==0.30.0
     #   referencing
 secretstorage==3.5.0 ; sys_platform == 'linux'
     # via keyring
+shellingham==1.5.4
+    # via typer
 six==1.17.0
     # via python-dateutil
-sse-starlette==3.2.0
+sse-starlette==3.3.4
     # via mcp
 starlette==0.52.1
     # via
@@ -219,7 +223,7 @@ starlette==0.52.1
     #   mcp
     #   sse-starlette
     #   uml-mcp
-typer==0.9.4
+typer==0.24.1
     # via uml-mcp
 typing-extensions==4.15.0
     # via
@@ -233,7 +237,6 @@ typing-extensions==4.15.0
     #   pydantic-core
     #   referencing
     #   starlette
-    #   typer
     #   typing-inspection
 typing-inspection==0.4.2
     # via
@@ -245,7 +248,7 @@ uncalled-for==0.3.1
     # via fastmcp
 urllib3==2.6.3
     # via requests
-uvicorn==0.40.0
+uvicorn==0.45.0
     # via
     #   fastmcp
     #   mcp

--- a/uv.lock
+++ b/uv.lock
@@ -1203,15 +1203,15 @@ wheels = [
 
 [[package]]
 name = "pymdown-extensions"
-version = "10.20.1"
+version = "10.21.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1e/6c/9e370934bfa30e889d12e61d0dae009991294f40055c238980066a7fbd83/pymdown_extensions-10.20.1.tar.gz", hash = "sha256:e7e39c865727338d434b55f1dd8da51febcffcaebd6e1a0b9c836243f660740a", size = 852860, upload-time = "2026-01-24T05:56:56.758Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/08/f1c908c581fd11913da4711ea7ba32c0eee40b0190000996bb863b0c9349/pymdown_extensions-10.21.2.tar.gz", hash = "sha256:c3f55a5b8a1d0edf6699e35dcbea71d978d34ff3fa79f3d807b8a5b3fa90fbdc", size = 853922, upload-time = "2026-03-29T15:01:55.233Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/40/6d/b6ee155462a0156b94312bdd82d2b92ea56e909740045a87ccb98bf52405/pymdown_extensions-10.20.1-py3-none-any.whl", hash = "sha256:24af7feacbca56504b313b7b418c4f5e1317bb5fea60f03d57be7fcc40912aa0", size = 268768, upload-time = "2026-01-24T05:56:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/27/a2fc51a4a122dfd1015e921ae9d22fee3d20b0b8080d9a704578bf9deece/pymdown_extensions-10.21.2-py3-none-any.whl", hash = "sha256:5c0fd2a2bea14eb39af8ff284f1066d898ab2187d81b889b75d46d4348c01638", size = 268901, upload-time = "2026-03-29T15:01:53.244Z" },
 ]
 
 [[package]]
@@ -1636,6 +1636,7 @@ dev = [
     { name = "mkdocs-minify-plugin" },
     { name = "mypy" },
     { name = "pre-commit" },
+    { name = "pymdown-extensions" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
@@ -1676,6 +1677,7 @@ dev = [
     { name = "mkdocs-minify-plugin", specifier = ">=0.8.0" },
     { name = "mypy", specifier = ">=1.19.1" },
     { name = "pre-commit", specifier = ">=4.5.1" },
+    { name = "pymdown-extensions", specifier = ">=10.21.2" },
     { name = "pytest", specifier = ">=9.0.2" },
     { name = "pytest-asyncio", specifier = ">=0.21.1" },
     { name = "pytest-cov", specifier = ">=7.0.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -5,6 +5,7 @@ requires-python = "==3.12.*"
 [manifest]
 overrides = [
     { name = "anyio", specifier = "==4.13.0" },
+    { name = "attrs", specifier = ">=26,<27" },
     { name = "authlib", specifier = "==1.7.0" },
     { name = "cachetools", specifier = "==7.0.5" },
     { name = "certifi", specifier = "==2026.2.25" },
@@ -12,9 +13,12 @@ overrides = [
     { name = "cyclopts", specifier = "==4.10.2" },
     { name = "docstring-parser", specifier = "==0.18.0" },
     { name = "graphviz", specifier = "==0.21" },
-    { name = "pygments", specifier = "<2.20" },
+    { name = "idna", specifier = "==3.12" },
+    { name = "pygments", specifier = "==2.20.0" },
+    { name = "pyjwt", specifier = "==2.12.1" },
     { name = "python-dotenv", specifier = "==1.2.2" },
     { name = "rich", specifier = "==14.3.4" },
+    { name = "sse-starlette", specifier = "==3.3.4" },
 ]
 
 [[package]]
@@ -31,11 +35,11 @@ wheels = [
 
 [[package]]
 name = "aiofiles"
-version = "23.2.1"
+version = "25.1.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/af/41/cfed10bc64d774f497a86e5ede9248e1d062db675504b41c320954d99641/aiofiles-23.2.1.tar.gz", hash = "sha256:84ec2218d8419404abcb9f0c02df3f34c6e0a68ed41072acfb1cef5cbc29051a", size = 32072, upload-time = "2023-08-09T15:23:11.564Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/c3/534eac40372d8ee36ef40df62ec129bee4fdb5ad9706e58a29be53b2c970/aiofiles-25.1.0.tar.gz", hash = "sha256:a8d728f0a29de45dc521f18f07297428d56992a742f0cd2701ba86e44d23d5b2", size = 46354, upload-time = "2025-10-09T20:51:04.358Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c5/19/5af6804c4cc0fed83f47bff6e413a98a36618e7d40185cd36e69737f3b0e/aiofiles-23.2.1-py3-none-any.whl", hash = "sha256:19297512c647d4b27a2cf7c34caa7e405c0d60b5560618a29a9fe027b18b0107", size = 15727, upload-time = "2023-08-09T15:23:09.774Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/8a/340a1555ae33d7354dbca4faa54948d76d89a27ceef032c8c3bc661d003e/aiofiles-25.1.0-py3-none-any.whl", hash = "sha256:abe311e527c862958650f9438e859c1fa7568a141b22abcd015e120e86a85695", size = 14668, upload-time = "2025-10-09T20:51:03.174Z" },
 ]
 
 [[package]]
@@ -71,11 +75,11 @@ wheels = [
 
 [[package]]
 name = "attrs"
-version = "25.4.0"
+version = "26.1.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6b/5c/685e6633917e101e5dcb62b9dd76946cbb57c26e133bae9e0cd36033c0a9/attrs-25.4.0.tar.gz", hash = "sha256:16d5969b87f0859ef33a48b35d55ac1be6e42ae49d5e853b597db70c35c57e11", size = 934251, upload-time = "2025-10-06T13:54:44.725Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3a/2a/7cc015f5b9f5db42b7d48157e23356022889fc354a2813c15934b7cb5c0e/attrs-25.4.0-py3-none-any.whl", hash = "sha256:adcf7e2a1fb3b36ac48d97835bb6d8ade15b8dcce26aba8bf1d14847b57a3373", size = 67615, upload-time = "2025-10-06T13:54:43.17Z" },
+    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
 ]
 
 [[package]]
@@ -552,11 +556,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.11"
+version = "3.12"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/12/2948fbe5513d062169bd91f7d7b1cd97bc8894f32946b71fa39f6e63ca0c/idna-3.12.tar.gz", hash = "sha256:724e9952cc9e2bd7550ea784adb098d837ab5267ef67a1ab9cf7846bdbdd8254", size = 194350, upload-time = "2026-04-21T13:32:48.916Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+    { url = "https://files.pythonhosted.org/packages/53/b2/acc33950394b3becb2b664741a0c0889c7ef9f9ffbfa8d47eddb53a50abd/idna-3.12-py3-none-any.whl", hash = "sha256:60ffaa1858fac94c9c124728c24fcde8160f3fb4a7f79aa8cdd33a9d1af60a67", size = 68634, upload-time = "2026-04-21T13:32:47.403Z" },
 ]
 
 [[package]]
@@ -789,7 +793,7 @@ dependencies = [
     { name = "jsonschema" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
-    { name = "pyjwt", extra = ["crypto"] },
+    { name = "pyjwt" },
     { name = "python-multipart" },
     { name = "pywin32", marker = "sys_platform == 'win32'" },
     { name = "sse-starlette" },
@@ -1181,25 +1185,20 @@ wheels = [
 
 [[package]]
 name = "pygments"
-version = "2.19.2"
+version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
 ]
 
 [[package]]
 name = "pyjwt"
-version = "2.11.0"
+version = "2.12.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5c/5a/b46fa56bf322901eee5b0454a34343cdbdae202cd421775a8ee4e42fd519/pyjwt-2.11.0.tar.gz", hash = "sha256:35f95c1f0fbe5d5ba6e43f00271c275f7a1a4db1dab27bf708073b75318ea623", size = 98019, upload-time = "2026-01-30T19:59:55.694Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6f/01/c26ce75ba460d5cd503da9e13b21a33804d38c2165dec7b716d06b13010c/pyjwt-2.11.0-py3-none-any.whl", hash = "sha256:94a6bde30eb5c8e04fee991062b534071fd1439ef58d2adc9ccb823e7bcd0469", size = 28224, upload-time = "2026-01-30T19:59:54.539Z" },
-]
-
-[package.optional-dependencies]
-crypto = [
-    { name = "cryptography" },
+    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
 ]
 
 [[package]]
@@ -1362,7 +1361,7 @@ wheels = [
 
 [[package]]
 name = "requests"
-version = "2.32.5"
+version = "2.33.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
@@ -1370,9 +1369,9 @@ dependencies = [
     { name = "idna" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/a4/98b9c7c6428a668bf7e42ebb7c79d576a1c3c1e3ae2d47e674b468388871/requests-2.33.1.tar.gz", hash = "sha256:18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517", size = 134120, upload-time = "2026-03-30T16:09:15.531Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl", hash = "sha256:4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a", size = 64947, upload-time = "2026-03-30T16:09:13.83Z" },
 ]
 
 [[package]]
@@ -1463,6 +1462,15 @@ wheels = [
 ]
 
 [[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1482,15 +1490,15 @@ wheels = [
 
 [[package]]
 name = "sse-starlette"
-version = "3.2.0"
+version = "3.3.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "starlette" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8b/8d/00d280c03ffd39aaee0e86ec81e2d3b9253036a0f93f51d10503adef0e65/sse_starlette-3.2.0.tar.gz", hash = "sha256:8127594edfb51abe44eac9c49e59b0b01f1039d0c7461c6fd91d4e03b70da422", size = 27253, upload-time = "2026-01-17T13:11:05.62Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/26/8c/f9290339ef6d79badbc010f067cd769d6601ec11a57d78569c683fb4dd87/sse_starlette-3.3.4.tar.gz", hash = "sha256:aaf92fc067af8a5427192895ac028e947b484ac01edbc3caf00e7e7137c7bef1", size = 32427, upload-time = "2026-03-29T09:00:23.307Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/96/7f/832f015020844a8b8f7a9cbc103dd76ba8e3875004c41e08440ea3a2b41a/sse_starlette-3.2.0-py3-none-any.whl", hash = "sha256:5876954bd51920fc2cd51baee47a080eb88a37b5b784e615abb0b283f801cdbf", size = 12763, upload-time = "2026-01-17T13:11:03.775Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/7f/3de5402f39890ac5660b86bcf5c03f9d855dad5c4ed764866d7b592b46fd/sse_starlette-3.3.4-py3-none-any.whl", hash = "sha256:84bb06e58939a8b38d8341f1bc9792f06c2b53f48c608dd207582b664fc8f3c1", size = 14330, upload-time = "2026-03-29T09:00:21.846Z" },
 ]
 
 [[package]]
@@ -1550,15 +1558,17 @@ wheels = [
 
 [[package]]
 name = "typer"
-version = "0.9.4"
+version = "0.24.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "annotated-doc" },
     { name = "click" },
-    { name = "typing-extensions" },
+    { name = "rich" },
+    { name = "shellingham" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e9/7d/b1e0399aa5e27071f0042784681d28417f3e526c61f62c8e3635ee5ad334/typer-0.9.4.tar.gz", hash = "sha256:f714c2d90afae3a7929fcd72a3abb08df305e1ff61719381384211c4070af57f", size = 276061, upload-time = "2024-03-23T17:07:55.568Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f5/24/cb09efec5cc954f7f9b930bf8279447d24618bb6758d4f6adf2574c41780/typer-0.24.1.tar.gz", hash = "sha256:e39b4732d65fbdcde189ae76cf7cd48aeae72919dea1fdfc16593be016256b45", size = 118613, upload-time = "2026-02-21T16:54:40.609Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/62/39/82c9d3e10979851847361d922a373bdfef4091020da7f893acfaf07c0225/typer-0.9.4-py3-none-any.whl", hash = "sha256:aa6c4a4e2329d868b80ecbaf16f807f2b54e192209d7ac9dd42691d63f7a54eb", size = 45973, upload-time = "2024-03-23T17:07:53.985Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/91/48db081e7a63bb37284f9fbcefda7c44c277b18b0e13fbc36ea2335b71e6/typer-0.24.1-py3-none-any.whl", hash = "sha256:112c1f0ce578bfb4cab9ffdabc68f031416ebcc216536611ba21f04e9aa84c9e", size = 56085, upload-time = "2026-02-21T16:54:41.616Z" },
 ]
 
 [[package]]
@@ -1636,7 +1646,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "aiofiles", specifier = ">=23.2.1,<24.0.0" },
+    { name = "aiofiles", specifier = ">=25,<26" },
     { name = "charset-normalizer", specifier = "==3.4.7" },
     { name = "click", specifier = "==8.3.2" },
     { name = "fastapi", specifier = ">=0.128.0,<0.136.0" },
@@ -1651,11 +1661,11 @@ requires-dist = [
     { name = "python-dateutil", specifier = ">=2.8.2,<3.0.0" },
     { name = "python-dotenv", specifier = "==1.2.2" },
     { name = "python-multipart", specifier = ">=0.0.22,<0.1" },
-    { name = "requests", specifier = ">=2.28.0,<3.0.0" },
+    { name = "requests", specifier = ">=2.33.1,<3" },
     { name = "rich", specifier = "==14.3.4" },
     { name = "starlette", specifier = ">=0.52.0,<1.0.0" },
-    { name = "typer", specifier = ">=0.9.0,<0.10.0" },
-    { name = "uvicorn", specifier = ">=0.40.0,<0.41.0" },
+    { name = "typer", specifier = "==0.24.1" },
+    { name = "uvicorn", specifier = ">=0.45.0,<0.46" },
 ]
 
 [package.metadata.requires-dev]
@@ -1694,15 +1704,15 @@ wheels = [
 
 [[package]]
 name = "uvicorn"
-version = "0.40.0"
+version = "0.45.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
     { name = "h11" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c3/d1/8f3c683c9561a4e6689dd3b1d345c815f10f86acd044ee1fb9a4dcd0b8c5/uvicorn-0.40.0.tar.gz", hash = "sha256:839676675e87e73694518b5574fd0f24c9d97b46bea16df7b8c05ea1a51071ea", size = 81761, upload-time = "2025-12-21T14:16:22.45Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/eb/2e/62b0d9a2cfc8b4de6771322dae30f2db76c66dae9ec32e94e176a44ad563/uvicorn-0.45.0.tar.gz", hash = "sha256:3fe650df136c5bd2b9b06efc5980636344a2fbb840e9ddd86437d53144fa335d", size = 87818, upload-time = "2026-04-21T10:43:46.815Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3d/d8/2083a1daa7439a66f3a48589a57d576aa117726762618f6bb09fe3798796/uvicorn-0.40.0-py3-none-any.whl", hash = "sha256:c6c8f55bc8bf13eb6fa9ff87ad62308bbbc33d0b67f84293151efe87e0d5f2ee", size = 68502, upload-time = "2025-12-21T14:16:21.041Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/88/d0f7512465b166a4e931ccf7e77792be60fb88466a43964c7566cbaff752/uvicorn-0.45.0-py3-none-any.whl", hash = "sha256:2db26f588131aeec7439de00f2dd52d5f210710c1f01e407a52c90b880d1fd4f", size = 69838, upload-time = "2026-04-21T10:43:45.029Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Merge latest \main\ into this branch.
- Dependency upgrades already on branch: typer 0.24.1, uvicorn 0.45.0, aiofiles 25.x, requests 2.33.1, pygments 2.20.0, plus uv overrides for idna, attrs 26, sse-starlette, pyjwt (see \pyproject.toml\).
- **Dev:** require \pymdown-extensions>=10.21.2\ so \mkdocs build\ works with Pygments 2.20 (fixes HtmlFormatter \ilename=None\ crash).

## Verification (local)
- \uv sync --all-groups\, \uff check\, \uff format --check\
- \uv run pytest\ (333 passed, 6 skipped)
- \uv run mkdocs build\
- \uv build\


Made with [Cursor](https://cursor.com)