### PR TITLE
docs: add a live MCP status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Python >=3.12,<3.13](https://img.shields.io/badge/python-%3E%3D3.12%2C%3C3.13-blue.svg)](https://www.python.org/downloads/)
 [![MseeP.ai Security Assessment](https://img.shields.io/badge/MseeP.ai-Security%20Assessment-green)](https://mseep.ai/app/antoinebou12-uml-mcp)
+[![MCP status](https://mcpvitals.com/badge/6cfb821be2.svg)](https://mcpvitals.com/status/6cfb821be2)
 
 Generate UML and other diagrams through the [Model Context Protocol](https://modelcontextprotocol.io/).
 


### PR DESCRIPTION
Hi — this adds a status badge for the hosted Vercel endpoint so readers can tell at a glance whether it's up before configuring a client.

It performs the real MCP handshake rather than a plain HTTP check, and links to a public status page with latency history. Healthy with 4 tools now. Added alongside your existing badges; nothing else touched. Happy for you to close it.

---
*Disclosure: I build MCP Vitals, the service behind this badge — so I have an interest here. I also used an AI assistant to help prepare this PR. The check is real and reproducible without me: `npx @mcpvitals/cli check <your-endpoint>`. Close it freely if it isn't a fit.*