### PR TITLE
Adopt MCP 2026-07-28 stateless protocol support

### DIFF
--- a/mcp_core/core/server.py
+++ b/mcp_core/core/server.py
@@ -1,8 +1,20 @@
 """
-Core MCP server implementation
+Core MCP server implementation.
+
+The HTTP transport defaults to stateless mode for legacy MCP clients. Modern
+2026-07-28 clients are sessionless at the protocol level and are handled by
+FastMCP 4 / MCP Python SDK 2 without a protocol session.
 """
 
 import logging
+import os
+
+# Default HTTP deployments to stateless transport semantics. This removes
+# Mcp-Session-Id affinity for legacy clients too, which is important for Vercel,
+# Cloud Run, multi-worker Uvicorn, and other horizontally scaled deployments.
+# Operators can explicitly set FASTMCP_STATELESS_HTTP=false if they need a
+# legacy stateful deployment.
+os.environ.setdefault("FASTMCP_STATELESS_HTTP", "true")
 
 # Get logger
 logger = logging.getLogger(__name__)
@@ -24,9 +36,9 @@ def create_mcp_server():
     from ..tools.diagram_tools import register_diagram_tools
     from .config import MCP_SETTINGS
 
-    # Initialize MCP server
-    # Note: stateless_http is configured via the FASTMCP_STATELESS_HTTP env var
-    # (read by run_http_async/http_app at runtime, not the constructor)
+    # FastMCP 4 negotiates both the modern 2026-07-28 sessionless protocol and
+    # legacy protocol revisions on the same server. Transport-level stateless
+    # behavior for legacy HTTP clients is configured by FASTMCP_STATELESS_HTTP.
     logger.info(f"Creating MCP server: {MCP_SETTINGS.server_name}")
     server = FastMCP(MCP_SETTINGS.server_name)
 
@@ -83,7 +95,9 @@ def start_server(transport="stdio", host=None, port=None):
     elif transport == "http":
         if not host or not port:
             raise ValueError("Host and port must be specified for HTTP transport")
-        # FastMCP v3 removed run_http(); use run(transport="http") instead
+        # FastMCP v3+ uses run(transport="http"). FASTMCP_STATELESS_HTTP is
+        # intentionally set above so the same setting also applies when this
+        # server is embedded through http_app() in app.py.
         if hasattr(server, "run_http"):
             server.run_http(host=host, port=port)
         else:

--- a/mcp_core/tools/diagram_tools.py
+++ b/mcp_core/tools/diagram_tools.py
@@ -1,30 +1,27 @@
 """
-MCP tools for diagram generation using the decorator pattern
+MCP tools for diagram generation using the decorator pattern.
 """
 
+import asyncio
 import logging
 from typing import Any, Dict, List, Optional
 
 from pydantic import ValidationError
 
-
 from ..core.config import MCP_SETTINGS
 from ..core.diagram_catalog import get_diagram_types_dict
 from ..core.diagram_service import DiagramRequest, generate_from_request
 from ..core.diagram_validation import validate_uml_inputs
-
-# Import the tool decorator system
-from .tool_decorator import get_tool_registry, mcp_tool, register_tools_with_server
 from .schemas import GenerateUMLInput
+from .tool_decorator import get_tool_registry, mcp_tool, register_tools_with_server
 
 logger = logging.getLogger(__name__)
 
-# MCP tool annotations per best practices (diagram tools call Kroki, may write files)
 ANNOTATIONS_DIAGRAM = {
-    "readOnlyHint": False,  # May write files when output_dir provided
+    "readOnlyHint": False,
     "destructiveHint": False,
-    "idempotentHint": True,  # Same inputs produce same diagram via Kroki
-    "openWorldHint": True,  # Calls external Kroki service for rendering
+    "idempotentHint": True,
+    "openWorldHint": True,
 }
 
 ANNOTATIONS_VALIDATE = {
@@ -52,11 +49,7 @@ ANNOTATIONS_LIST = {
     annotations=ANNOTATIONS_LIST,
 )
 def list_diagram_types() -> Dict[str, Any]:
-    """Return the uml://types payload as a structured dict.
-
-    Keys are diagram type names (e.g. class, mermaid, c4plantuml); each value has
-    backend, description, and formats.
-    """
+    """Return the uml://types payload as a structured dict."""
     logger.info("Called list_diagram_types tool")
     return get_diagram_types_dict()
 
@@ -135,7 +128,35 @@ def generate_uml_batch(
     return {"results": results}
 
 
-# Main UML generation tool
+@mcp_tool(
+    name="generate_uml_batch_task",
+    description=(
+        "Generate a batch of diagrams using the MCP Tasks extension. Prefer this for "
+        "large batches or expensive renders so the client can poll task status instead "
+        "of holding one request open. Inputs and output match generate_uml_batch."
+    ),
+    category="uml",
+    example=(
+        "generate_uml_batch_task([{'diagram_type': 'mermaid', "
+        "'code': 'graph TD; A-->B;'}])"
+    ),
+    annotations=ANNOTATIONS_DIAGRAM,
+    task=True,
+)
+async def generate_uml_batch_task(
+    items: List[Dict[str, Any]],
+    output_dir: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Task-capable wrapper for expensive batch generation.
+
+    The existing synchronous batch tool is kept for compatibility. This wrapper
+    offloads its blocking render pipeline to a worker thread when executed in the
+    foreground, while FastMCP can execute it through the Tasks extension when the
+    client requests background execution.
+    """
+    return await asyncio.to_thread(generate_uml_batch, items, output_dir)
+
+
 @mcp_tool(
     description="Generate any UML or diagram by type (class, sequence, mermaid, d2, etc.)",
     category="uml",
@@ -153,24 +174,7 @@ def generate_uml(
     theme: Optional[str] = None,
     scale: float = 1.0,
 ) -> Dict[str, Any]:
-    """Generate a diagram using the specified diagram type.
-
-    Use when you need a diagram of any supported type. For complex diagrams the
-    default prompt guides planning first (type, elements, relationships), then
-    you call this tool with the final code.
-
-    Args:
-        diagram_type: Type of diagram (class, sequence, activity, mermaid, d2, etc.)
-        code: Diagram code in the syntax for the chosen type
-        output_dir: Directory to save the image. Omit or None for URL, playground,
-            and content_base64 only (no file write; use in serverless / read-only).
-        output_format: svg, png, pdf, jpeg, txt, or base64 (default: svg). See uml://formats per type.
-        theme: PlantUML theme for UML diagrams (e.g. cerulean)
-        scale: Scale factor for SVG only (default 1.0, min 0.1). Ignored for other formats.
-
-    Returns:
-        Dict with code, url, playground; local_path when output_dir set; content_base64 when not saving; or error.
-    """
+    """Generate a diagram using the specified diagram type."""
     logger.info(
         "Called generate_uml tool: type=%s, code length=%s",
         diagram_type,
@@ -203,21 +207,7 @@ def validate_uml(
     output_format: str = "svg",
     strict: bool = False,
 ) -> Dict[str, Any]:
-    """Check inputs and light structure without rendering.
-
-    Use to catch unsupported types, bad output_format for the type, empty code, or obvious
-    PlantUML/Mermaid/D2 issues before calling generate_uml.
-
-    Args:
-        diagram_type: Same as generate_uml (see uml://types).
-        code: Diagram source text.
-        output_format: Intended output format (default svg); must be allowed for the type.
-        strict: When True, apply extra Mermaid/D2 checks (no extra PlantUML rules).
-
-    Returns:
-        Dict with valid (bool), errors, suggestions, backend, diagram_type, prepared_code,
-        optional corrected_code when only trivial wrapping changed the text, and strict.
-    """
+    """Check inputs and light structure without rendering."""
     logger.info(
         "Called validate_uml tool: type=%s, code length=%s, strict=%s",
         diagram_type,
@@ -228,21 +218,10 @@ def validate_uml(
 
 
 def register_diagram_tools(server: Any) -> List[str]:
-    """
-    Register all diagram generation tools with the MCP server
-
-    Args:
-        server: The MCP server instance
-
-    Returns:
-        List of registered tool names
-    """
+    """Register all diagram generation tools with the MCP server."""
     logger.info("Registering diagram tools")
 
-    # Register all tools that were decorated with @mcp_tool
     registered_tools = register_tools_with_server(server)
-
-    # Store registered tools in MCP_SETTINGS.tools (which is a standard attribute)
     MCP_SETTINGS.tools = registered_tools
 
     logger.info("Registered %s diagram tools successfully", len(registered_tools))
@@ -252,10 +231,5 @@ def register_diagram_tools(server: Any) -> List[str]:
 
 
 def get_tool_info() -> Dict[str, Dict[str, Any]]:
-    """
-    Get information about all registered tools
-
-    Returns:
-        Dictionary mapping tool names to their information
-    """
+    """Get information about all registered tools."""
     return get_tool_registry()

--- a/mcp_core/tools/tool_decorator.py
+++ b/mcp_core/tools/tool_decorator.py
@@ -1,5 +1,5 @@
 """
-Decorator system for MCP tools
+Decorator system for MCP tools.
 """
 
 import inspect
@@ -21,9 +21,9 @@ def mcp_tool(
     required_params: Optional[List[str]] = None,
     example: Optional[str] = None,
     annotations: Optional[Dict[str, Any]] = None,
+    task: bool = False,
 ) -> Callable[[F], F]:
-    """
-    Decorator for registering a function as an MCP tool.
+    """Decorator for registering a function as an MCP tool.
 
     Args:
         name: Tool name (defaults to function name if not provided)
@@ -32,15 +32,11 @@ def mcp_tool(
         required_params: List of required parameter names
         example: Example usage of the tool
         annotations: MCP tool hints (readOnlyHint, destructiveHint, idempotentHint, openWorldHint)
+        task: Whether the tool supports the MCP Tasks extension. Task-enabled tools
+            must be async when registered with FastMCP.
 
     Returns:
         Decorated function
-
-    Example:
-        @mcp_tool(description="Generate a class diagram", category="uml")
-        def generate_class_diagram(code: str, output_dir: str) -> Dict[str, Any]:
-            # Implementation
-            return {"code": code, "url": "..."}
     """
 
     def decorator(func: F) -> F:
@@ -48,7 +44,6 @@ def mcp_tool(
         func_doc = inspect.getdoc(func) or ""
         func_description = description or func_doc.split("\n")[0] if func_doc else ""
 
-        # Get parameter annotations from function signature
         sig = inspect.signature(func)
         param_info = {}
 
@@ -72,7 +67,6 @@ def mcp_tool(
                 "default": param_default,
             }
 
-        # Store tool metadata
         _registered_tools[func_name] = {
             "function": func,
             "name": func_name,
@@ -83,6 +77,7 @@ def mcp_tool(
             or [p for p, info in param_info.items() if info["required"]],
             "example": example,
             "annotations": annotations or {},
+            "task": task,
             "return_type": (
                 sig.return_annotation
                 if sig.return_annotation is not inspect.Parameter.empty
@@ -90,22 +85,13 @@ def mcp_tool(
             ),
         }
 
-        # Return function unchanged
         return cast(F, func)
 
     return decorator
 
 
 def register_tools_with_server(server: Any) -> List[str]:
-    """
-    Register all decorated tools with the MCP server
-
-    Args:
-        server: The MCP server instance
-
-    Returns:
-        List of registered tool names
-    """
+    """Register all decorated tools with the MCP server."""
     logger.info(f"Registering {len(_registered_tools)} tools with the MCP server")
 
     registered_tools = []
@@ -114,42 +100,53 @@ def register_tools_with_server(server: Any) -> List[str]:
     for tool_name, tool_info in _registered_tools.items():
         func = tool_info["function"]
         annotations = tool_info.get("annotations") or {}
+        task_enabled = bool(tool_info.get("task", False))
 
-        # Build tool registration kwargs
-        tool_kwargs = {"name": tool_name, "description": tool_info["description"]}
+        tool_kwargs: Dict[str, Any] = {
+            "name": tool_name,
+            "description": tool_info["description"],
+        }
         if annotations:
             tool_kwargs["annotations"] = annotations
+        if task_enabled:
+            tool_kwargs["task"] = True
 
-        # Register with server (handle different server APIs)
+        # FastMCP 4 supports annotations and task=True. The compatibility
+        # fallbacks keep development mocks and older test doubles working.
         try:
             dec = server_any.tool(**tool_kwargs)
             dec(func)
         except TypeError:
             try:
-                # Try without annotations (server may not support them)
-                dec = server_any.tool(
-                    name=tool_name, description=tool_info["description"]
-                )
+                fallback_kwargs = {
+                    "name": tool_name,
+                    "description": tool_info["description"],
+                }
+                if annotations:
+                    fallback_kwargs["annotations"] = annotations
+                dec = server_any.tool(**fallback_kwargs)
                 dec(func)
             except TypeError:
                 try:
-                    # Try just passing the description (alternate style)
-                    dec = server_any.tool(tool_info["description"])
+                    dec = server_any.tool(
+                        name=tool_name, description=tool_info["description"]
+                    )
                     dec(func)
                 except TypeError:
-                    # Fallback to simple decorator with no args (basic style)
-                    server_any.tool(func)
+                    try:
+                        dec = server_any.tool(tool_info["description"])
+                        dec(func)
+                    except TypeError:
+                        server_any.tool(func)
 
-                # If that didn't throw an error but we need to rename the function
-                if tool_name != func.__name__:
-                    # Use the _tools dictionary directly if we can access it
-                    if hasattr(server, "_tools"):
-                        tools_map: Any = getattr(server, "_tools")
-                        tools_map[tool_name] = tools_map.pop(func.__name__, func)
-                    else:
-                        logger.warning(
-                            f"Could not rename tool '{func.__name__}' to '{tool_name}' - server API doesn't support it"
-                        )
+                    if tool_name != func.__name__:
+                        if hasattr(server, "_tools"):
+                            tools_map: Any = getattr(server, "_tools")
+                            tools_map[tool_name] = tools_map.pop(func.__name__, func)
+                        else:
+                            logger.warning(
+                                f"Could not rename tool '{func.__name__}' to '{tool_name}' - server API doesn't support it"
+                            )
 
         registered_tools.append(tool_name)
         logger.debug(f"Registered tool: {tool_name}")
@@ -158,22 +155,12 @@ def register_tools_with_server(server: Any) -> List[str]:
 
 
 def get_tool_registry() -> Dict[str, Dict[str, Any]]:
-    """
-    Get the registry of all tools registered with the decorator
-
-    Returns:
-        Dictionary of tool metadata
-    """
+    """Get information about all registered tools."""
     return _registered_tools
 
 
 def get_tool_categories() -> Dict[str, List[str]]:
-    """
-    Get tools organized by category
-
-    Returns:
-        Dictionary mapping categories to tool names
-    """
+    """Get tools organized by category."""
     categories: Dict[str, List[str]] = {}
 
     for tool_name, tool_info in _registered_tools.items():
@@ -187,7 +174,5 @@ def get_tool_categories() -> Dict[str, List[str]]:
 
 
 def clear_tool_registry():
-    """
-    Clear the tool registry (mainly for testing)
-    """
+    """Clear the tool registry (mainly for testing)."""
     _registered_tools.clear()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,12 +38,14 @@ requests = ">=2.34.2,<3"
 click = "==8.4.2"
 charset-normalizer = "==3.4.7"
 python-dateutil = "^2.8.2"
-# Add diagram-related dependencies
+# Diagram-related dependencies
 graphviz = ">=0.21,<0.22"
 pillow = "^12.0.0"
-# If fastmcp is not your own module but a dependency (2.3.1+ for http_app / Streamable HTTP)
-fastmcp = ">=2.3.1,<4"
-mcp = ">=1.27.1,<2.0.0"
+# FastMCP 4 + MCP Python SDK 2 provide dual-era support: the stateless
+# 2026-07-28 protocol plus legacy 2025 clients on the same endpoint.
+# FastMCP 4 is currently pre-release, so pin exactly until stable 4.0 ships.
+fastmcp = { version = "==4.0.0b1", extras = ["tasks"] }
+mcp = ">=2.0.0,<3.0.0"
 
 # Transitive-only pins (direct versions live in [tool.poetry.dependencies] above).
 # Revisit when bumping fastmcp / httpx / starlette; drop entries when upstream aligns.

--- a/tests/test_mcp_2026.py
+++ b/tests/test_mcp_2026.py
@@ -1,0 +1,32 @@
+"""Regression tests for the MCP 2026-07-28 migration surface."""
+
+import importlib
+import os
+
+
+def test_http_defaults_to_stateless(monkeypatch):
+    monkeypatch.delenv("FASTMCP_STATELESS_HTTP", raising=False)
+
+    import mcp_core.core.server as server_module
+
+    importlib.reload(server_module)
+    assert os.environ["FASTMCP_STATELESS_HTTP"] == "true"
+
+
+def test_operator_can_override_stateless_default(monkeypatch):
+    monkeypatch.setenv("FASTMCP_STATELESS_HTTP", "false")
+
+    import mcp_core.core.server as server_module
+
+    importlib.reload(server_module)
+    assert os.environ["FASTMCP_STATELESS_HTTP"] == "false"
+
+
+def test_batch_task_is_advertised_as_task_capable():
+    # Import registers diagram tools in the local decorator registry.
+    from mcp_core.tools import diagram_tools  # noqa: F401
+    from mcp_core.tools.tool_decorator import get_tool_registry
+
+    registry = get_tool_registry()
+    assert "generate_uml_batch_task" in registry
+    assert registry["generate_uml_batch_task"]["task"] is True


### PR DESCRIPTION
Superseded by #297, which is now the single consolidated integration PR for MCP 2026-07-28 stateless support, cache hints, conformance CI, dependency updates, PlantUML auth fixes, and Vercel deployment hardening.

All MCP 2026 work from this branch is retained in #297's history.