### PR TITLE
Fix strict Mermaid validation and stress-test accounting

### DIFF
--- a/mcp_core/core/diagram_validation.py
+++ b/mcp_core/core/diagram_validation.py
@@ -45,6 +45,40 @@ _MERMAID_HEAD = re.compile(
     re.IGNORECASE | re.MULTILINE,
 )
 
+# Mermaid sequence messages use [Actor][Arrow][Actor]:Message. Keep this intentionally
+# conservative: catch only a message line that ends immediately after a documented
+# standard arrow token (optionally followed by an activation +/- marker). This rejects
+# obvious malformed input such as `A->>` without trying to duplicate Mermaid's parser.
+_MERMAID_SEQUENCE_DANGLING_ARROW = re.compile(
+    r"(?:<<-->>|<<->>|-->>|->>|-->|->|--x|-x|--\)|-\))\s*[+-]?\s*$"
+)
+
+
+def _strict_mermaid_sequence_errors(prepared_code: str) -> List[str]:
+    errors: List[str] = []
+    lines = prepared_code.splitlines()
+    first_content_seen = False
+
+    for line_number, line in enumerate(lines, 1):
+        stripped = line.strip()
+        if not stripped or stripped.startswith("%%"):
+            continue
+
+        if not first_content_seen:
+            first_content_seen = True
+            if stripped.lower().startswith("sequencediagram"):
+                continue
+            return errors
+
+        if _MERMAID_SEQUENCE_DANGLING_ARROW.search(stripped):
+            errors.append(
+                "Mermaid (strict): sequence message on line "
+                f"{line_number} has an arrow but no target actor."
+            )
+            break
+
+    return errors
+
 
 def _structural_errors_strict_mermaid(prepared_code: str) -> List[str]:
     """Extra checks when strict=True; conservative to limit false positives."""
@@ -62,6 +96,7 @@ def _structural_errors_strict_mermaid(prepared_code: str) -> List[str]:
         errors.append(
             "Mermaid (strict): subgraph blocks typically need a matching `end`."
         )
+    errors.extend(_strict_mermaid_sequence_errors(s))
     return errors
 
 
@@ -84,6 +119,10 @@ def _suggestions_for_errors(errors: List[str]) -> List[str]:
         if "Mermaid" in e:
             sug.append(
                 "Start with a diagram keyword such as `graph TD`, `flowchart LR`, or `sequenceDiagram`."
+            )
+        if "target actor" in e:
+            sug.append(
+                "Complete sequence messages with a target actor, for example `A->>B: message`."
             )
         if "D2" in e:
             sug.append("Define at least one shape or connection (e.g. `a -> b`).")

--- a/tests/prompts/kroki_stress_test_reporting_rules.md
+++ b/tests/prompts/kroki_stress_test_reporting_rules.md
@@ -1,0 +1,94 @@
+# Kroki MCP stress-test reporting rules
+
+Use this addendum with `tests/prompts/kroki_full_catalog_stress_test.md` when an agent executes the full tool-only stress test.
+
+These rules are intentionally strict. They prevent a successful render run from hiding validation defects or under-counting tool invocations.
+
+## Execution accounting
+
+Initialize these counters to zero before the first MCP call:
+
+- `list_diagram_types_calls`
+- `validate_uml_calls`
+- `generate_uml_calls`
+- `generate_uml_batch_calls`
+
+Increment the relevant counter for **every attempted MCP tool invocation**, before evaluating whether the call succeeded or returned a controlled error.
+
+Controlled-error calls still count. In particular:
+
+- the invalid `generate_uml` call from Negative 2 counts;
+- the empty `generate_uml_batch` call from Negative 3 counts;
+- the mixed valid/invalid `generate_uml_batch` call from Negative 4 counts.
+
+Do not infer counts from successful artifacts. Count actual tool invocations.
+
+For the current full stress-test specification, if every phase executes exactly once, the expected totals are:
+
+- `list_diagram_types_calls = 2`
+  - initial catalog discovery;
+  - post-negative-test health check.
+- `validate_uml_calls = 17`
+  - 7 complex Mermaid validations;
+  - 9 PlantUML-family validations;
+  - 1 malformed-Mermaid negative validation.
+- `generate_uml_calls = 3`
+  - 2 identical stateless repeatability renders;
+  - 1 invalid-diagram-type negative call.
+- `generate_uml_batch_calls = 6`
+  - 1 complex Mermaid batch;
+  - 1 PlantUML-family batch;
+  - 2 full-catalog batches;
+  - 1 empty-batch negative call;
+  - 1 mixed valid/invalid negative batch.
+- `total_mcp_tool_calls = 28`.
+
+If a validation failure causes a complex-case render to be omitted as required by the main prompt, report both the actual counters and the expected baseline, and explain the delta. Never fabricate a call just to match the baseline.
+
+## Strict Mermaid negative-test semantics
+
+Negative 1 uses:
+
+```text
+sequenceDiagram
+A->>
+```
+
+with `diagram_type="mermaid"`, `output_format="svg"`, and `strict=true`.
+
+This negative test passes **only** when `validate_uml` returns `valid: false` or an equivalent controlled validation failure.
+
+The test does **not** pass merely because the MCP connection remains healthy.
+
+If the validator returns `valid: true` for that malformed sequence message:
+
+- record `NEGATIVE 1: FAIL`;
+- count the `validate_uml` invocation normally;
+- continue the remaining safe tests;
+- force the overall stress-test verdict to FAIL.
+
+After the strict validator fix, the expected result is a validation error explaining that the sequence message has an arrow but no target actor.
+
+## Final report requirements
+
+The final report must include a tool-call accounting table:
+
+| MCP tool | Actual calls | Expected baseline | Status |
+| --- | ---: | ---: | --- |
+| `list_diagram_types` | N | 2 | PASS/EXPLAIN |
+| `validate_uml` | N | 17 | PASS/EXPLAIN |
+| `generate_uml` | N | 3 | PASS/EXPLAIN |
+| `generate_uml_batch` | N | 6 | PASS/EXPLAIN |
+| **Total** | N | **28** | PASS/EXPLAIN |
+
+Also report the four negative tests individually. Do not collapse them into `4/4` unless each expected error condition was actually satisfied.
+
+Overall PASS requires all conditions from the main stress-test prompt plus:
+
+- malformed Mermaid is rejected by strict validation;
+- the tool-call ledger includes failed/negative invocations;
+- the reported counters reconcile with the actual transcript.
+
+If any of those conditions fail, finish with:
+
+`MCP_KROKI_TOOL_ONLY_STRESS_TEST: FAIL - <short reason>`

--- a/tests/test_diagram_validation.py
+++ b/tests/test_diagram_validation.py
@@ -57,6 +57,29 @@ def test_validate_uml_strict_mermaid_rejects_garbage():
     assert any("strict" in e.lower() for e in out["errors"])
 
 
+def test_validate_uml_strict_mermaid_rejects_dangling_sequence_arrow():
+    out = validate_uml_inputs(
+        "mermaid",
+        "sequenceDiagram\nA->>",
+        "svg",
+        strict=True,
+    )
+    assert out["valid"] is False
+    assert any("target actor" in e.lower() for e in out["errors"])
+    assert any("A->>B: message" in s for s in out["suggestions"])
+
+
+def test_validate_uml_strict_mermaid_accepts_complete_sequence_message():
+    out = validate_uml_inputs(
+        "mermaid",
+        "sequenceDiagram\nA->>B: message\nB-->>A: reply",
+        "svg",
+        strict=True,
+    )
+    assert out["valid"] is True
+    assert out["errors"] == []
+
+
 def test_validate_uml_strict_mermaid_ok():
     out = validate_uml_inputs(
         "mermaid",

--- a/tests/test_kroki_stress_prompt.py
+++ b/tests/test_kroki_stress_prompt.py
@@ -6,10 +6,17 @@ from mcp_core.core.config import MCP_SETTINGS
 
 
 PROMPT_PATH = Path(__file__).parent / "prompts" / "kroki_full_catalog_stress_test.md"
+REPORTING_RULES_PATH = (
+    Path(__file__).parent / "prompts" / "kroki_stress_test_reporting_rules.md"
+)
 
 
 def _prompt_text() -> str:
     return PROMPT_PATH.read_text(encoding="utf-8")
+
+
+def _reporting_rules_text() -> str:
+    return REPORTING_RULES_PATH.read_text(encoding="utf-8")
 
 
 def test_stress_prompt_tracks_every_runtime_diagram_type():
@@ -65,3 +72,24 @@ def test_stress_prompt_keeps_complex_repeatability_and_negative_phases():
     assert "items must not be empty" in text
     assert "MCP_KROKI_TOOL_ONLY_STRESS_TEST: PASS" in text
     assert "MCP_KROKI_TOOL_ONLY_STRESS_TEST: FAIL - <short reason>" in text
+
+
+def test_reporting_rules_count_every_attempted_tool_call():
+    text = _reporting_rules_text()
+
+    assert "every attempted MCP tool invocation" in text
+    assert "generate_uml_calls = 3" in text
+    assert "generate_uml_batch_calls = 6" in text
+    assert "validate_uml_calls = 17" in text
+    assert "list_diagram_types_calls = 2" in text
+    assert "total_mcp_tool_calls = 28" in text
+    assert "Do not infer counts from successful artifacts" in text
+
+
+def test_reporting_rules_require_strict_mermaid_rejection():
+    text = _reporting_rules_text()
+
+    assert "sequenceDiagram\nA->>" in text
+    assert "passes **only** when `validate_uml` returns `valid: false`" in text
+    assert "record `NEGATIVE 1: FAIL`" in text
+    assert "force the overall stress-test verdict to FAIL" in text


### PR DESCRIPTION
## Summary

Tighten strict Mermaid sequence validation and make the MCP stress-test accounting rules exact.

## Strict Mermaid validation

- reject obvious dangling Mermaid sequence arrows such as `sequenceDiagram\nA->>` when `strict=true`
- keep the check deliberately conservative instead of reimplementing the full Mermaid parser
- report an actionable `no target actor` error and suggest a complete message such as `A->>B: message`
- add regressions proving malformed sequence input is rejected while complete sequence messages still pass

Mermaid documents sequence messages as `[Actor][Arrow][Actor]:Message text`, so an arrow with no target actor is structurally incomplete.

## Stress-test reporting

Add `tests/prompts/kroki_stress_test_reporting_rules.md` as an agent reporting contract for the full catalog stress test.

Every attempted tool invocation now counts, including controlled-error negative tests. For a complete current run the baseline is:

- `list_diagram_types`: 2
- `validate_uml`: 17
- `generate_uml`: 3
- `generate_uml_batch`: 6
- total MCP tool calls: 28

Negative Mermaid validation passes only when the malformed fixture is actually rejected. Connection stability alone is not enough to mark that negative test as PASS.

## Regression guards

- strict Mermaid dangling-arrow regression test
- valid sequence-message regression test
- prompt reporting rules must preserve the exact accounting baseline
- prompt reporting rules must force overall FAIL when malformed Mermaid is accepted

## Scope

- `mcp_core/core/diagram_validation.py`
- `tests/test_diagram_validation.py`
- `tests/prompts/kroki_stress_test_reporting_rules.md`
- `tests/test_kroki_stress_prompt.py`

Note: the Python files were rewritten through the GitHub contents API, so the diff also reflects line-ending normalization in addition to the focused logic/test changes.