### PR TITLE
feat(mcp): harden result contracts, rendering, validation, and HTTP security

### DIFF
--- a/mcp_core/core/diagram_service.py
+++ b/mcp_core/core/diagram_service.py
@@ -1,8 +1,9 @@
-"""
-Diagram generation entry for MCP tools: validate once, then render.
-"""
+"""Diagram generation entry for MCP tools: validate once, then render."""
+
+from __future__ import annotations
 
 import logging
+import time
 from dataclasses import dataclass
 from typing import Any, Dict, Optional
 
@@ -11,6 +12,7 @@ from pydantic import ValidationError
 from mcp_core.tools.schemas import GenerateUMLInput
 
 from .config import MCP_SETTINGS
+from .render_cache import build_render_cache_key, get_render_cache
 from .utils import generate_diagram
 
 logger = logging.getLogger(__name__)
@@ -28,26 +30,87 @@ class DiagramRequest:
     scale: float = 1.0
 
 
-def _validation_error_response(code: str, exc: ValidationError) -> Dict[str, Any]:
+def _error_detail(
+    message: str,
+    *,
+    diagram_type: Optional[str],
+    backend: Optional[str] = None,
+    code: str = "RENDER_FAILED",
+) -> dict[str, Any]:
+    lowered = message.lower()
+    retryable = any(
+        token in lowered
+        for token in (
+            "temporarily unavailable",
+            "cannot connect",
+            "connection",
+            "timeout",
+            "timed out",
+            "http 429",
+            "http 502",
+            "http 503",
+            "http 504",
+        )
+    )
+    return {
+        "code": code,
+        "message": message,
+        "diagram_type": diagram_type,
+        "backend": backend,
+        "retryable": retryable,
+        "line": None,
+        "column": None,
+        "suggestion": None,
+    }
+
+
+def _validation_error_response(
+    source_code: str,
+    exc: ValidationError,
+    *,
+    diagram_type: Optional[str] = None,
+    output_format: Optional[str] = None,
+) -> Dict[str, Any]:
     parts = []
     for err in exc.errors():
         loc = err.get("loc", ())
         name = loc[0] if loc else "input"
         parts.append(f"{name}: {err['msg']}")
     err_msg = "; ".join(parts)
+    message = f"Validation error: {err_msg}"
     return {
-        "code": code,
+        "code": source_code,
+        "success": False,
+        "diagram_type": diagram_type,
+        "output_format": output_format,
         "url": None,
         "playground": None,
         "local_path": None,
-        "error": f"Validation error: {err_msg}",
+        "error": message,
+        "error_detail": _error_detail(
+            message,
+            diagram_type=diagram_type,
+            code="INVALID_INPUT",
+        ),
+        "cache_hit": False,
     }
 
 
+def _renderer_identity() -> str:
+    """Stable renderer/config identity included in cache keys."""
+    return "|".join(
+        (
+            f"kroki={MCP_SETTINGS.kroki_server}",
+            f"plantuml={MCP_SETTINGS.plantuml_server}",
+            f"fallback={int(bool(MCP_SETTINGS.diagram_fallback_enabled))}",
+            f"url_only={int(bool(MCP_SETTINGS.url_only))}",
+            f"memory_only={int(bool(MCP_SETTINGS.memory_only))}",
+        )
+    )
+
+
 def generate_from_request(req: DiagramRequest) -> Dict[str, Any]:
-    """
-    Validate with GenerateUMLInput, ensure diagram_type is configured, then generate_diagram.
-    """
+    """Validate, optionally use cache, then render a diagram."""
     try:
         validated = GenerateUMLInput(
             diagram_type=req.diagram_type,
@@ -57,8 +120,13 @@ def generate_from_request(req: DiagramRequest) -> Dict[str, Any]:
             theme=req.theme,
             scale=req.scale,
         )
-    except ValidationError as e:
-        return _validation_error_response(req.code, e)
+    except ValidationError as exc:
+        return _validation_error_response(
+            req.code,
+            exc,
+            diagram_type=(req.diagram_type or "").strip().lower() or None,
+            output_format=(req.output_format or "").strip().lower() or None,
+        )
 
     dt_key = validated.diagram_type.lower()
     types_map = getattr(MCP_SETTINGS, "diagram_types", None) or {}
@@ -70,13 +138,46 @@ def generate_from_request(req: DiagramRequest) -> Dict[str, Any]:
         logger.error(error_msg)
         return {
             "code": validated.code,
+            "success": False,
+            "diagram_type": dt_key,
+            "output_format": validated.output_format,
             "url": None,
             "playground": None,
             "local_path": None,
             "error": error_msg,
+            "error_detail": _error_detail(
+                error_msg,
+                diagram_type=dt_key,
+                code="UNSUPPORTED_DIAGRAM_TYPE",
+            ),
+            "cache_hit": False,
         }
 
-    return generate_diagram(
+    cache = get_render_cache()
+    cache_key: Optional[str] = None
+    # File-producing calls are intentionally not cached because a cached local_path may
+    # refer to a different request or a file that has since been removed.
+    if validated.output_dir is None and cache.enabled:
+        cache_key = build_render_cache_key(
+            diagram_type=dt_key,
+            code=validated.code,
+            output_format=validated.output_format,
+            theme=validated.theme,
+            scale=validated.scale,
+            renderer_identity=_renderer_identity(),
+        )
+        lookup_start = time.perf_counter()
+        cached = cache.get(cache_key)
+        lookup_ms = (time.perf_counter() - lookup_start) * 1000.0
+        if cached is not None:
+            cached["success"] = True
+            cached["diagram_type"] = dt_key
+            cached["output_format"] = validated.output_format
+            cached["cache_hit"] = True
+            cached["cache_lookup_ms"] = round(lookup_ms, 3)
+            return cached
+
+    result = generate_diagram(
         validated.diagram_type,
         validated.code,
         validated.output_format,
@@ -84,3 +185,21 @@ def generate_from_request(req: DiagramRequest) -> Dict[str, Any]:
         validated.theme,
         validated.scale,
     )
+    out = dict(result)
+    out["diagram_type"] = dt_key
+    out["output_format"] = validated.output_format
+    out["success"] = not bool(out.get("error"))
+    out["cache_hit"] = False
+
+    if out.get("error"):
+        backend = getattr(types_map.get(dt_key), "backend", None)
+        out["error_detail"] = _error_detail(
+            str(out["error"]),
+            diagram_type=dt_key,
+            backend=backend,
+        )
+        return out
+
+    if cache_key is not None:
+        cache.set(cache_key, out)
+    return out

--- a/mcp_core/core/diagram_validation.py
+++ b/mcp_core/core/diagram_validation.py
@@ -1,18 +1,13 @@
-"""
-Local validation for diagram code before render (no network calls).
-
-Reuses GenerateUMLInput for type/format/length rules, then applies light structural checks.
-"""
+"""Local validation for diagram code before render (no network calls)."""
 
 from __future__ import annotations
 
 import re
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from pydantic import ValidationError
 
 from ..tools.schemas import GenerateUMLInput
-
 from .config import MCP_SETTINGS
 from .diagram_rendering import prepare_diagram_code
 
@@ -45,13 +40,10 @@ _MERMAID_HEAD = re.compile(
     re.IGNORECASE | re.MULTILINE,
 )
 
-# Mermaid sequence messages use [Actor][Arrow][Actor]:Message. Keep this intentionally
-# conservative: catch only a message line that ends immediately after a documented
-# standard arrow token (optionally followed by an activation +/- marker). This rejects
-# obvious malformed input such as `A->>` without trying to duplicate Mermaid's parser.
 _MERMAID_SEQUENCE_DANGLING_ARROW = re.compile(
     r"(?:<<-->>|<<->>|-->>|->>|-->|->|--x|-x|--\)|-\))\s*[+-]?\s*$"
 )
+_LINE_NUMBER = re.compile(r"\bline\s+(\d+)\b", re.IGNORECASE)
 
 
 def _strict_mermaid_sequence_errors(prepared_code: str) -> List[str]:
@@ -83,54 +75,122 @@ def _strict_mermaid_sequence_errors(prepared_code: str) -> List[str]:
 def _structural_errors_strict_mermaid(prepared_code: str) -> List[str]:
     """Extra checks when strict=True; conservative to limit false positives."""
     errors: List[str] = []
-    s = prepared_code.strip()
-    if not s:
+    source = prepared_code.strip()
+    if not source:
         errors.append("Mermaid diagram code is empty.")
         return errors
-    if not _MERMAID_HEAD.search(s):
+    if not _MERMAID_HEAD.search(source):
         errors.append(
             "Mermaid (strict): start with a diagram keyword such as "
             "`graph TD`, `flowchart LR`, or `sequenceDiagram`."
         )
-    if "subgraph" in s.lower() and "end" not in s.lower():
+    if "subgraph" in source.lower() and "end" not in source.lower():
         errors.append(
             "Mermaid (strict): subgraph blocks typically need a matching `end`."
         )
-    errors.extend(_strict_mermaid_sequence_errors(s))
+    errors.extend(_strict_mermaid_sequence_errors(source))
     return errors
 
 
 def _structural_errors_strict_d2(prepared_code: str) -> List[str]:
     errors: List[str] = []
-    for i, line in enumerate(prepared_code.splitlines(), 1):
+    for line_number, line in enumerate(prepared_code.splitlines(), 1):
         if line.count('"') % 2 != 0:
-            errors.append(f"D2 (strict): line {i} may have an unclosed double quote.")
+            errors.append(
+                f"D2 (strict): line {line_number} may have an unclosed double quote."
+            )
             break
     return errors
 
 
 def _suggestions_for_errors(errors: List[str]) -> List[str]:
-    sug: List[str] = []
-    for e in errors:
-        if "@startuml" in e or "@enduml" in e:
-            sug.append(
+    suggestions: List[str] = []
+    for error in errors:
+        if "@startuml" in error or "@enduml" in error:
+            suggestions.append(
                 "Close every @startuml with @enduml, or use a single unbroken diagram block."
             )
-        if "Mermaid" in e:
-            sug.append(
+        if "Mermaid" in error:
+            suggestions.append(
                 "Start with a diagram keyword such as `graph TD`, `flowchart LR`, or `sequenceDiagram`."
             )
-        if "target actor" in e:
-            sug.append(
+        if "target actor" in error:
+            suggestions.append(
                 "Complete sequence messages with a target actor, for example `A->>B: message`."
             )
-        if "D2" in e:
-            sug.append("Define at least one shape or connection (e.g. `a -> b`).")
-        if "strict" in e.lower() and "Mermaid" in e:
-            sug.append(
+        if "D2" in error:
+            suggestions.append("Define at least one shape or connection (e.g. `a -> b`).")
+        if "strict" in error.lower() and "Mermaid" in error:
+            suggestions.append(
                 "Use a standard Mermaid diagram header on the first line (e.g. graph TD;)."
             )
-    return list(dict.fromkeys(sug))
+    return list(dict.fromkeys(suggestions))
+
+
+def _diagnostic_code(message: str) -> str:
+    lower = message.lower()
+    if "unsupported diagram type" in lower:
+        return "UNSUPPORTED_DIAGRAM_TYPE"
+    if "output_format" in lower or "not supported" in lower:
+        return "UNSUPPORTED_OUTPUT_FORMAT"
+    if "exceeds maximum length" in lower:
+        return "SOURCE_TOO_LARGE"
+    if "target actor" in lower:
+        return "MERMAID_DANGLING_ARROW"
+    if "diagram keyword" in lower:
+        return "MERMAID_MISSING_HEADER"
+    if "subgraph" in lower:
+        return "MERMAID_UNCLOSED_SUBGRAPH"
+    if "unclosed double quote" in lower:
+        return "D2_UNCLOSED_QUOTE"
+    if "@startuml" in lower or "@enduml" in lower:
+        return "PLANTUML_UNBALANCED_BLOCK"
+    if "too short" in lower or "empty" in lower:
+        return "SOURCE_TOO_SHORT"
+    return "INVALID_DIAGRAM"
+
+
+def _line_from_message(message: str) -> Optional[int]:
+    match = _LINE_NUMBER.search(message)
+    return int(match.group(1)) if match else None
+
+
+def _build_diagnostics(
+    errors: List[str], suggestions: List[str]
+) -> list[dict[str, Any]]:
+    diagnostics: list[dict[str, Any]] = []
+    for index, message in enumerate(errors):
+        suggestion = suggestions[index] if index < len(suggestions) else None
+        diagnostics.append(
+            {
+                "severity": "error",
+                "code": _diagnostic_code(message),
+                "message": message,
+                "line": _line_from_message(message),
+                "column": None,
+                "suggestion": suggestion,
+            }
+        )
+    return diagnostics
+
+
+def _normalization_changes(
+    original: str, prepared: str, backend: str
+) -> list[str]:
+    if prepared == original.strip():
+        return []
+    changes: list[str] = []
+    stripped = original.strip()
+    if backend == "plantuml":
+        if "@startuml" not in stripped:
+            changes.append("added @startuml wrapper")
+        if "@enduml" not in stripped:
+            changes.append("added @enduml wrapper")
+    elif backend == "tikz" and "\\documentclass" not in stripped:
+        changes.append("wrapped TikZ snippet in a standalone document")
+    if not changes:
+        changes.append("normalized diagram source")
+    return changes
 
 
 def validate_uml_inputs(
@@ -139,12 +199,7 @@ def validate_uml_inputs(
     output_format: str = "svg",
     strict: bool = False,
 ) -> Dict[str, Any]:
-    """
-    Validate diagram inputs without calling Kroki or other renderers.
-
-    Returns a dict with valid, errors, suggestions, backend, diagram_type, and prepared_code
-    (when schema validation passed).
-    """
+    """Validate diagram inputs locally and return actionable diagnostics."""
     try:
         validated = GenerateUMLInput(
             diagram_type=diagram_type,
@@ -155,19 +210,25 @@ def validate_uml_inputs(
             scale=1.0,
         )
     except ValidationError as exc:
-        errs: List[str] = []
-        for err in exc.errors():
-            loc = err.get("loc", ())
+        errors: List[str] = []
+        for error in exc.errors():
+            loc = error.get("loc", ())
             name = str(loc[0]) if loc else "input"
-            errs.append(f"{name}: {err['msg']}")
+            errors.append(f"{name}: {error['msg']}")
+        suggestions = _suggestions_for_errors(errors)
         return {
             "valid": False,
             "diagram_type": (diagram_type or "").strip().lower() or None,
             "backend": None,
-            "errors": errs,
-            "suggestions": _suggestions_for_errors(errs),
+            "errors": errors,
+            "warnings": [],
+            "suggestions": suggestions,
+            "diagnostics": _build_diagnostics(errors, suggestions),
             "corrected_code": None,
             "prepared_code": None,
+            "strict": strict,
+            "normalized": False,
+            "changes": [],
         }
 
     dt_key = validated.diagram_type
@@ -181,15 +242,20 @@ def validate_uml_inputs(
         elif cfg.backend == "d2":
             extra.extend(_structural_errors_strict_d2(prepared))
     all_errors = structural + extra
-    valid = len(all_errors) == 0
+    suggestions = _suggestions_for_errors(all_errors)
+    changes = _normalization_changes(validated.code, prepared, cfg.backend)
 
     return {
-        "valid": valid,
+        "valid": len(all_errors) == 0,
         "diagram_type": dt_key,
         "backend": cfg.backend,
         "errors": all_errors,
-        "suggestions": _suggestions_for_errors(all_errors),
+        "warnings": [],
+        "suggestions": suggestions,
+        "diagnostics": _build_diagnostics(all_errors, suggestions),
         "corrected_code": prepared if prepared != validated.code.strip() else None,
         "prepared_code": prepared,
         "strict": strict,
+        "normalized": bool(changes),
+        "changes": changes,
     }

--- a/mcp_core/core/http_observability.py
+++ b/mcp_core/core/http_observability.py
@@ -1,13 +1,11 @@
-"""
-Optional HTTP rate limiting and request ID propagation for FastAPI (e.g. app.py).
-"""
+"""Optional HTTP rate limiting and request ID propagation for FastAPI."""
 
 from __future__ import annotations
 
 import logging
 import time
 from collections import defaultdict, deque
-from typing import Deque, Dict
+from typing import Deque, Dict, Tuple
 from uuid import uuid4
 
 from starlette.middleware.base import BaseHTTPMiddleware
@@ -16,27 +14,48 @@ from starlette.responses import JSONResponse, Response
 
 logger = logging.getLogger(__name__)
 
+# In-memory and intentionally per process. A distributed implementation can replace
+# this helper later without changing HTTP response semantics.
 _rate_buckets: Dict[str, Deque[float]] = defaultdict(deque)
 
 
-def _rate_limited(client_ip: str, limit_per_minute: int) -> bool:
+def _rate_limit_state(
+    client_ip: str,
+    limit_per_minute: int,
+) -> Tuple[bool, int, int]:
+    """Return (limited, remaining, retry_after_seconds) for one client IP."""
     if limit_per_minute <= 0:
-        return False
+        return False, 0, 0
+
     now = time.monotonic()
-    q = _rate_buckets[client_ip]
-    while q and now - q[0] > 60.0:
-        q.popleft()
-    if len(q) >= limit_per_minute:
-        return True
-    q.append(now)
-    return False
+    queue = _rate_buckets[client_ip]
+    while queue and now - queue[0] > 60.0:
+        queue.popleft()
+
+    if len(queue) >= limit_per_minute:
+        retry_after = max(1, int(60.0 - (now - queue[0]) + 0.999))
+        return True, 0, retry_after
+
+    queue.append(now)
+    remaining = max(0, limit_per_minute - len(queue))
+    return False, remaining, 0
+
+
+def _rate_limited(client_ip: str, limit_per_minute: int) -> bool:
+    """Backward-compatible boolean helper used by existing tests/callers."""
+    limited, _, _ = _rate_limit_state(client_ip, limit_per_minute)
+    return limited
 
 
 class RequestIdAndRateLimitMiddleware(BaseHTTPMiddleware):
-    """Assign X-Request-ID; optionally rate-limit selected paths (MCP_RATE_LIMIT_PER_MINUTE)."""
+    """Assign X-Request-ID and optionally rate-limit generation endpoints.
+
+    The limiter is process-local. Horizontally scaled deployments should use a
+    distributed limiter at the platform/edge or replace this implementation.
+    """
 
     async def dispatch(self, request: Request, call_next) -> Response:
-        rid = request.headers.get("x-request-id") or str(uuid4())
+        request_id = request.headers.get("x-request-id") or str(uuid4())
         try:
             from .config import MCP_SETTINGS
 
@@ -45,29 +64,41 @@ class RequestIdAndRateLimitMiddleware(BaseHTTPMiddleware):
             limit = 0
 
         path = request.url.path
-        if limit > 0 and path.startswith(
-            ("/mcp", "/generate_diagram", "/kroki_encode")
-        ):
-            ip = request.client.host if request.client else "unknown"
-            if _rate_limited(ip, limit):
+        protected = path.startswith(("/mcp", "/generate_diagram", "/kroki_encode"))
+        remaining = None
+        if limit > 0 and protected:
+            # Deliberately trust only the socket peer here. Forwarded headers require an
+            # explicitly trusted proxy configuration and are not interpreted by this app.
+            client_ip = request.client.host if request.client else "unknown"
+            limited, remaining_value, retry_after = _rate_limit_state(client_ip, limit)
+            remaining = remaining_value
+            if limited:
                 logger.warning(
                     "rate_limit exceeded request_id=%s path=%s ip=%s",
-                    rid,
+                    request_id,
                     path,
-                    ip,
+                    client_ip,
                 )
                 return JSONResponse(
                     {"detail": "Rate limit exceeded. Try again later."},
                     status_code=429,
-                    headers={"X-Request-ID": rid},
+                    headers={
+                        "X-Request-ID": request_id,
+                        "Retry-After": str(retry_after),
+                        "X-RateLimit-Limit": str(limit),
+                        "X-RateLimit-Remaining": "0",
+                    },
                 )
 
         logger.info(
             "http_request request_id=%s method=%s path=%s",
-            rid,
+            request_id,
             request.method,
             path,
         )
         response = await call_next(request)
-        response.headers["X-Request-ID"] = rid
+        response.headers["X-Request-ID"] = request_id
+        if limit > 0 and protected and remaining is not None:
+            response.headers["X-RateLimit-Limit"] = str(limit)
+            response.headers["X-RateLimit-Remaining"] = str(remaining)
         return response

--- a/mcp_core/core/render_cache.py
+++ b/mcp_core/core/render_cache.py
@@ -1,0 +1,190 @@
+"""Small bounded in-process cache for rendered diagram results.
+
+The cache intentionally sits behind a tiny interface so a distributed implementation
+can replace it later without changing tool code. It is process-local by design.
+"""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import os
+import threading
+import time
+from collections import OrderedDict
+from dataclasses import dataclass
+from typing import Any, Optional
+
+
+def _env_bool(name: str, default: bool) -> bool:
+    value = os.environ.get(name, "").strip().lower()
+    if not value:
+        return default
+    return value in {"1", "true", "yes", "on"}
+
+
+def _env_int(name: str, default: int, minimum: int = 0) -> int:
+    try:
+        value = int(os.environ.get(name, str(default)))
+    except ValueError:
+        return default
+    return max(minimum, value)
+
+
+def _env_float(name: str, default: float, minimum: float = 0.0) -> float:
+    try:
+        value = float(os.environ.get(name, str(default)))
+    except ValueError:
+        return default
+    return max(minimum, value)
+
+
+@dataclass
+class _CacheEntry:
+    value: dict[str, Any]
+    created_at: float
+    size_bytes: int
+
+
+class InMemoryRenderCache:
+    """Thread-safe TTL/LRU cache with entry and byte bounds."""
+
+    def __init__(self) -> None:
+        self._lock = threading.RLock()
+        self._entries: OrderedDict[str, _CacheEntry] = OrderedDict()
+        self._bytes = 0
+        self._hits = 0
+        self._misses = 0
+
+    @property
+    def enabled(self) -> bool:
+        # Tests default to disabled so existing mocks continue to assert render calls.
+        testing = _env_bool("TESTING", False)
+        return _env_bool("MCP_RENDER_CACHE_ENABLED", not testing)
+
+    @property
+    def ttl_seconds(self) -> float:
+        return _env_float("MCP_RENDER_CACHE_TTL_SECONDS", 300.0)
+
+    @property
+    def max_entries(self) -> int:
+        return _env_int("MCP_RENDER_CACHE_MAX_ENTRIES", 128)
+
+    @property
+    def max_bytes(self) -> int:
+        return _env_int("MCP_RENDER_CACHE_MAX_BYTES", 32 * 1024 * 1024)
+
+    @staticmethod
+    def _value_size(value: dict[str, Any]) -> int:
+        try:
+            encoded = json.dumps(
+                value,
+                sort_keys=True,
+                separators=(",", ":"),
+                default=str,
+            ).encode("utf-8")
+            return len(encoded)
+        except (TypeError, ValueError):
+            return 0
+
+    def _expired(self, entry: _CacheEntry, now: float) -> bool:
+        ttl = self.ttl_seconds
+        return ttl <= 0 or now - entry.created_at >= ttl
+
+    def _remove(self, key: str) -> None:
+        entry = self._entries.pop(key, None)
+        if entry is not None:
+            self._bytes = max(0, self._bytes - entry.size_bytes)
+
+    def get(self, key: str) -> Optional[dict[str, Any]]:
+        if not self.enabled:
+            return None
+        now = time.monotonic()
+        with self._lock:
+            entry = self._entries.get(key)
+            if entry is None:
+                self._misses += 1
+                return None
+            if self._expired(entry, now):
+                self._remove(key)
+                self._misses += 1
+                return None
+            self._entries.move_to_end(key)
+            self._hits += 1
+            return copy.deepcopy(entry.value)
+
+    def set(self, key: str, value: dict[str, Any]) -> None:
+        if not self.enabled or self.max_entries <= 0 or self.max_bytes <= 0:
+            return
+        size = self._value_size(value)
+        if size <= 0 or size > self.max_bytes:
+            return
+        with self._lock:
+            self._remove(key)
+            self._entries[key] = _CacheEntry(
+                value=copy.deepcopy(value),
+                created_at=time.monotonic(),
+                size_bytes=size,
+            )
+            self._bytes += size
+            while (
+                len(self._entries) > self.max_entries
+                or self._bytes > self.max_bytes
+            ):
+                oldest_key = next(iter(self._entries))
+                self._remove(oldest_key)
+
+    def clear(self) -> None:
+        with self._lock:
+            self._entries.clear()
+            self._bytes = 0
+            self._hits = 0
+            self._misses = 0
+
+    def stats(self) -> dict[str, int]:
+        with self._lock:
+            return {
+                "entries": len(self._entries),
+                "bytes": self._bytes,
+                "hits": self._hits,
+                "misses": self._misses,
+            }
+
+
+def build_render_cache_key(
+    *,
+    diagram_type: str,
+    code: str,
+    output_format: str,
+    theme: Optional[str],
+    scale: float,
+    renderer_identity: str,
+) -> str:
+    """Return a deterministic key for all inputs that can affect render output."""
+    payload = {
+        "schema": 1,
+        "diagram_type": diagram_type,
+        "code": code.strip(),
+        "output_format": output_format,
+        "theme": theme or "",
+        "scale": scale,
+        "renderer_identity": renderer_identity,
+    }
+    raw = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(raw).hexdigest()
+
+
+_RENDER_CACHE = InMemoryRenderCache()
+
+
+def get_render_cache() -> InMemoryRenderCache:
+    """Return the process-local render cache singleton."""
+    return _RENDER_CACHE
+
+
+__all__ = [
+    "InMemoryRenderCache",
+    "build_render_cache_key",
+    "get_render_cache",
+]

--- a/mcp_core/core/server.py
+++ b/mcp_core/core/server.py
@@ -1,72 +1,94 @@
-"""
-Core MCP server implementation.
+"""Core MCP server implementation.
 
 The HTTP transport defaults to stateless mode for legacy MCP clients. Modern
 2026-07-28 clients are sessionless at the protocol level and are handled by
 FastMCP 4 / MCP Python SDK 2 without a protocol session.
 """
 
+from __future__ import annotations
+
+import json
 import logging
 import os
+from typing import Any
 
 # Default HTTP deployments to stateless transport semantics. This removes
 # Mcp-Session-Id affinity for legacy clients too, which is important for Vercel,
 # Cloud Run, multi-worker Uvicorn, and other horizontally scaled deployments.
-# Operators can explicitly set FASTMCP_STATELESS_HTTP=false if they need a
-# legacy stateful deployment.
 os.environ.setdefault("FASTMCP_STATELESS_HTTP", "true")
 
-# Get logger
 logger = logging.getLogger(__name__)
 
-# Create a singleton MCP server instance
 _mcp_server = None
 
 
-def get_mcp_cache_policy() -> dict[str, object]:
+def _parse_env_list(value: str) -> list[str]:
+    """Accept either a JSON array or a comma-separated allowlist."""
+    raw = value.strip()
+    if not raw:
+        return []
+    if raw.startswith("["):
+        try:
+            decoded = json.loads(raw)
+        except json.JSONDecodeError:
+            decoded = None
+        if isinstance(decoded, list):
+            return [str(item).strip() for item in decoded if str(item).strip()]
+    return [item.strip() for item in raw.split(",") if item.strip()]
+
+
+def _configure_fastmcp_http_security() -> None:
+    """Map UML-MCP security env vars to FastMCP's native request guard.
+
+    With no explicit allowlists FastMCP uses ``auto`` protection, which protects
+    localhost-bound direct servers without breaking reverse-proxy/serverless hosts.
+    Providing MCP_ALLOWED_HOSTS and/or MCP_ALLOWED_ORIGINS enables strict checking.
+    """
+    hosts = _parse_env_list(os.environ.get("MCP_ALLOWED_HOSTS", ""))
+    origins = _parse_env_list(os.environ.get("MCP_ALLOWED_ORIGINS", ""))
+
+    if hosts:
+        os.environ["FASTMCP_HTTP_ALLOWED_HOSTS"] = json.dumps(hosts)
+    if origins:
+        os.environ["FASTMCP_HTTP_ALLOWED_ORIGINS"] = json.dumps(origins)
+
+    if hosts or origins:
+        os.environ["FASTMCP_HTTP_HOST_ORIGIN_PROTECTION"] = "true"
+    else:
+        os.environ.setdefault("FASTMCP_HTTP_HOST_ORIGIN_PROTECTION", "auto")
+
+
+_configure_fastmcp_http_security()
+
+
+def get_mcp_cache_policy() -> dict[str, Any]:
     """Return FastMCP 4 server-wide SEP-2549 cache policy.
 
-    FastMCP 4.0.0b1 exposes cache hints as ``cache_ttl`` (seconds) and
-    ``cache_scope`` constructor arguments. The policy is intentionally public
-    because UML-MCP's tools, prompts, resource catalog and documentation
-    resources are deployment metadata rather than authorization-specific data.
-
-    FastMCP applies this uniform hint to every MCP 2026 cacheable method:
-    ``tools/list``, ``prompts/list``, ``resources/list``,
-    ``resources/templates/list``, ``resources/read`` and ``server/discover``.
-    Legacy protocol responses are unaffected.
+    The policy is intentionally public because UML-MCP's tools, prompts, resource
+    catalog and documentation resources are deployment metadata rather than
+    authorization-specific data.
     """
     return {"cache_ttl": 300, "cache_scope": "public"}
 
 
 def create_mcp_server():
-    """Create and configure the MCP server with all tools and resources.
-
-    Returns:
-        Configured FastMCP server instance
-    """
-    # Lazy import to avoid circular dependencies
+    """Create and configure the server with all tools, resources, and prompts."""
     from ..prompts.diagram_prompts import register_diagram_prompts
     from ..resources.diagram_resources import register_diagram_resources
     from ..server.fastmcp_wrapper import FastMCP
     from ..tools.diagram_tools import register_diagram_tools
     from .config import MCP_SETTINGS
 
-    # FastMCP 4 negotiates both the modern 2026-07-28 sessionless protocol and
-    # legacy protocol revisions on the same server. Transport-level stateless
-    # behavior for legacy HTTP clients is configured by FASTMCP_STATELESS_HTTP.
-    logger.info(f"Creating MCP server: {MCP_SETTINGS.server_name}")
+    logger.info("Creating MCP server: %s", MCP_SETTINGS.server_name)
     server = FastMCP(
         MCP_SETTINGS.server_name,
         **get_mcp_cache_policy(),
     )
 
-    # Register all tools, resources, and prompts
     tool_names = register_diagram_tools(server)
     resource_names = register_diagram_resources(server)
     prompt_names = register_diagram_prompts(server)
 
-    # Update settings with registered tools and prompts
     MCP_SETTINGS.tools = tool_names
     MCP_SETTINGS.prompts = prompt_names
     MCP_SETTINGS.resources = resource_names
@@ -81,11 +103,7 @@ def create_mcp_server():
 
 
 def get_mcp_server():
-    """Get the singleton MCP server instance.
-
-    Returns:
-        FastMCP server instance
-    """
+    """Get the singleton MCP server instance."""
     global _mcp_server
     if _mcp_server is None:
         _mcp_server = create_mcp_server()
@@ -93,20 +111,14 @@ def get_mcp_server():
 
 
 def main():
-    """Entry point for the mcp-server console script (argparse, Rich UI, then start server)."""
+    """Entry point for the mcp-server console script."""
     from .cli import run
 
     run()
 
 
 def start_server(transport="stdio", host=None, port=None):
-    """Start the MCP server with the specified transport.
-
-    Args:
-        transport (str): Transport protocol to use ('stdio' or 'http')
-        host (str, optional): Host address for HTTP transport
-        port (int, optional): Port number for HTTP transport
-    """
+    """Start the MCP server with stdio or HTTP transport."""
     server = get_mcp_server()
 
     if transport == "stdio":
@@ -114,9 +126,6 @@ def start_server(transport="stdio", host=None, port=None):
     elif transport == "http":
         if not host or not port:
             raise ValueError("Host and port must be specified for HTTP transport")
-        # FastMCP v3+ uses run(transport="http"). FASTMCP_STATELESS_HTTP is
-        # intentionally set above so the same setting also applies when this
-        # server is embedded through http_app() in app.py.
         if hasattr(server, "run_http"):
             server.run_http(host=host, port=port)
         else:

--- a/mcp_core/tools/diagram_tools.py
+++ b/mcp_core/tools/diagram_tools.py
@@ -1,8 +1,10 @@
-"""
-MCP tools for diagram generation using the decorator pattern.
-"""
+"""MCP tools for diagram generation using the decorator pattern."""
+
+from __future__ import annotations
 
 import logging
+import os
+from concurrent.futures import ThreadPoolExecutor
 from typing import Any, Dict, List, Optional
 
 from pydantic import ValidationError
@@ -11,7 +13,13 @@ from ..core.config import MCP_SETTINGS
 from ..core.diagram_catalog import get_diagram_types_dict
 from ..core.diagram_service import DiagramRequest, generate_from_request
 from ..core.diagram_validation import validate_uml_inputs
-from .schemas import BatchDiagramResult, DiagramResult, DiagramTypesOutput, GenerateUMLInput, ValidationResult
+from .schemas import (
+    BatchDiagramResult,
+    DiagramResult,
+    DiagramTypesOutput,
+    GenerateUMLInput,
+    ValidationResult,
+)
 from .tool_decorator import get_tool_registry, mcp_tool, register_tools_with_server
 
 logger = logging.getLogger(__name__)
@@ -38,20 +46,65 @@ ANNOTATIONS_LIST = {
 }
 
 
+def _bounded_limit(limit: Optional[int]) -> Optional[int]:
+    if limit is None:
+        return None
+    return max(1, min(int(limit), 100))
+
+
 @mcp_tool(
     description=(
-        "List supported diagram types with Kroki backend, description, and formats "
-        "(same data as uml://types resource). Use when the client cannot read resources."
+        "Find supported diagram types and their renderer/formats. Input optional query, "
+        "backend, output_format, and limit filters; returns matching type metadata. Use "
+        "this when you are unsure which diagram type or format to choose."
     ),
     category="uml",
-    example="list_diagram_types()",
-    annotations=ANNOTATIONS_LIST,
+    example="list_diagram_types(query='sequence', output_format='svg')",
+    annotations={**ANNOTATIONS_LIST, "title": "List Diagram Types"},
     output_schema=DiagramTypesOutput,
 )
-def list_diagram_types() -> Dict[str, Any]:
-    """Return the uml://types payload as a structured dict."""
-    logger.info("Called list_diagram_types tool")
-    return get_diagram_types_dict()
+def list_diagram_types(
+    query: Optional[str] = None,
+    backend: Optional[str] = None,
+    output_format: Optional[str] = None,
+    limit: Optional[int] = None,
+) -> Dict[str, Any]:
+    """Return optionally filtered diagram type metadata."""
+    logger.info(
+        "Called list_diagram_types: query=%s backend=%s format=%s limit=%s",
+        query,
+        backend,
+        output_format,
+        limit,
+    )
+    types_map = get_diagram_types_dict()
+    query_value = (query or "").strip().lower()
+    backend_value = (backend or "").strip().lower()
+    format_value = (output_format or "").strip().lower()
+
+    filtered: dict[str, Any] = {}
+    for name, info in types_map.items():
+        if query_value:
+            haystack = " ".join(
+                (
+                    name,
+                    str(info.get("backend", "")),
+                    str(info.get("description", "")),
+                )
+            ).lower()
+            if query_value not in haystack:
+                continue
+        if backend_value and str(info.get("backend", "")).lower() != backend_value:
+            continue
+        if format_value and format_value not in {
+            str(fmt).lower() for fmt in info.get("formats", [])
+        }:
+            continue
+        filtered[name] = info
+        bounded = _bounded_limit(limit)
+        if bounded is not None and len(filtered) >= bounded:
+            break
+    return filtered
 
 
 def _format_validation_error(exc: ValidationError) -> str:
@@ -63,58 +116,36 @@ def _format_validation_error(exc: ValidationError) -> str:
     return "; ".join(parts)
 
 
-@mcp_tool(
-    description=(
-        "Generate multiple diagrams in one call. Each item is like generate_uml "
-        "(diagram_type, code, output_format?, theme?, scale?). Optional shared output_dir "
-        "for all items. Returns a list of per-index results or errors."
-    ),
-    category="uml",
-    example=(
-        "generate_uml_batch([{'diagram_type': 'mermaid', 'code': 'graph TD; A-->B;'}], "
-        "output_dir=None)"
-    ),
-    annotations=ANNOTATIONS_DIAGRAM,
-    output_schema=BatchDiagramResult,
-)
-def generate_uml_batch(
-    items: List[Dict[str, Any]],
-    output_dir: Optional[str] = None,
+def _batch_concurrency(item_count: int) -> int:
+    try:
+        configured = int(os.environ.get("MCP_BATCH_CONCURRENCY", "4"))
+    except ValueError:
+        configured = 4
+    configured = max(1, min(configured, 16))
+    return max(1, min(configured, item_count))
+
+
+def _render_batch_item(
+    index: int,
+    raw: Any,
+    output_dir: Optional[str],
 ) -> Dict[str, Any]:
-    """Render multiple diagrams; failures are collected per index without stopping the batch."""
-    logger.info(
-        "Called generate_uml_batch: count=%s, output_dir=%s",
-        len(items) if items else 0,
-        output_dir,
-    )
-    if not items:
+    if not isinstance(raw, dict):
         return {
-            "error": "items must not be empty",
-            "results": [],
+            "index": index,
+            "success": False,
+            "error": f"items[{index}] must be an object with diagram_type and code",
         }
-    max_n = MCP_SETTINGS.batch_max_items
-    if len(items) > max_n:
+    try:
+        validated = GenerateUMLInput.model_validate({**raw, "output_dir": output_dir})
+    except ValidationError as exc:
         return {
-            "error": f"At most {max_n} items allowed (MCP_BATCH_MAX_ITEMS).",
-            "results": [],
+            "index": index,
+            "success": False,
+            "error": _format_validation_error(exc),
         }
-    results: List[Dict[str, Any]] = []
-    for i, raw in enumerate(items):
-        if not isinstance(raw, dict):
-            results.append(
-                {
-                    "index": i,
-                    "error": f"items[{i}] must be an object with diagram_type and code",
-                }
-            )
-            continue
-        try:
-            validated = GenerateUMLInput.model_validate(
-                {**raw, "output_dir": output_dir}
-            )
-        except ValidationError as e:
-            results.append({"index": i, "error": _format_validation_error(e)})
-            continue
+
+    try:
         out = generate_from_request(
             DiagramRequest(
                 diagram_type=validated.diagram_type,
@@ -125,18 +156,74 @@ def generate_uml_batch(
                 scale=validated.scale,
             )
         )
-        results.append({"index": i, **out})
+        return {"index": index, **out}
+    except Exception as exc:  # noqa: BLE001 - isolate each independent batch item
+        logger.exception("Unexpected batch item failure at index=%s", index)
+        return {
+            "index": index,
+            "success": False,
+            "diagram_type": validated.diagram_type,
+            "output_format": validated.output_format,
+            "error": f"Unexpected batch render failure: {type(exc).__name__}: {exc!s}",
+        }
+
+
+@mcp_tool(
+    description=(
+        "Render several independent diagrams in one call using bounded concurrency. Input "
+        "items use the same diagram_type/code/format/theme/scale fields as generate_uml; "
+        "returns ordered per-index results and keeps partial failures isolated. Use this for "
+        "multiple diagrams, not repeated repair attempts for one invalid diagram."
+    ),
+    category="uml",
+    example=(
+        "generate_uml_batch([{'diagram_type': 'mermaid', 'code': 'graph TD; A-->B;'}])"
+    ),
+    annotations={**ANNOTATIONS_DIAGRAM, "title": "Generate Diagram Batch"},
+    output_schema=BatchDiagramResult,
+)
+def generate_uml_batch(
+    items: List[Dict[str, Any]],
+    output_dir: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Render multiple diagrams with bounded concurrency and stable ordering."""
+    logger.info(
+        "Called generate_uml_batch: count=%s, output_dir=%s",
+        len(items) if items else 0,
+        output_dir,
+    )
+    if not items:
+        return {"error": "items must not be empty", "results": []}
+
+    max_n = MCP_SETTINGS.batch_max_items
+    if len(items) > max_n:
+        return {
+            "error": f"At most {max_n} items allowed (MCP_BATCH_MAX_ITEMS).",
+            "results": [],
+        }
+
+    workers = _batch_concurrency(len(items))
+    with ThreadPoolExecutor(max_workers=workers, thread_name_prefix="uml-batch") as pool:
+        futures = [
+            pool.submit(_render_batch_item, index, raw, output_dir)
+            for index, raw in enumerate(items)
+        ]
+        # Futures are consumed in submission order so output ordering is deterministic,
+        # even though the independent renders execute concurrently.
+        results = [future.result() for future in futures]
     return {"results": results}
 
 
 @mcp_tool(
-    description="Generate any UML or diagram by type (class, sequence, mermaid, d2, etc.)",
-    category="uml",
-    example=(
-        "generate_uml('mermaid', 'graph TD; A-->B;')  # URL/base64 only; "
-        "or generate_uml('class', code, './output') to save"
+    description=(
+        "Render one UML or diagram from source code. Input diagram_type, code, optional "
+        "output_format/theme/scale/output_dir; returns renderer metadata plus URL and "
+        "inline image data when appropriate. Use when you already have valid or nearly "
+        "valid diagram source; call validate_uml first for uncertain complex syntax."
     ),
-    annotations=ANNOTATIONS_DIAGRAM,
+    category="uml",
+    example="generate_uml('mermaid', 'graph TD; A-->B;')",
+    annotations={**ANNOTATIONS_DIAGRAM, "title": "Generate Diagram"},
     output_schema=DiagramResult,
 )
 def generate_uml(
@@ -167,12 +254,14 @@ def generate_uml(
 
 @mcp_tool(
     description=(
-        "Validate diagram type, format, code length, and basic syntax locally before render "
-        "(no Kroki call). Returns errors and suggestions."
+        "Validate diagram type, format, size, and syntax locally without rendering. Input "
+        "diagram_type/code/output_format and optional strict=true for additional Mermaid/D2 "
+        "checks; returns structured diagnostics, suggestions, and deterministic normalization "
+        "details. Use before rendering complex or uncertain source."
     ),
     category="uml",
     example="validate_uml('class', '@startuml\\nclass A\\n@enduml', 'svg')",
-    annotations=ANNOTATIONS_VALIDATE,
+    annotations={**ANNOTATIONS_VALIDATE, "title": "Validate Diagram"},
     output_schema=ValidationResult,
 )
 def validate_uml(
@@ -194,13 +283,10 @@ def validate_uml(
 def register_diagram_tools(server: Any) -> List[str]:
     """Register all diagram generation tools with the MCP server."""
     logger.info("Registering diagram tools")
-
     registered_tools = register_tools_with_server(server)
     MCP_SETTINGS.tools = registered_tools
-
     logger.info("Registered %s diagram tools successfully", len(registered_tools))
     logger.debug("Registered tools: %s", registered_tools)
-
     return registered_tools
 
 

--- a/mcp_core/tools/schemas.py
+++ b/mcp_core/tools/schemas.py
@@ -1,10 +1,26 @@
-"""
-Pydantic schemas for MCP tool inputs and outputs.
-"""
+"""Pydantic schemas for MCP tool inputs and outputs."""
 
+from __future__ import annotations
+
+import os
+from pathlib import Path
 from typing import Any, Optional
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    RootModel,
+    field_validator,
+    model_validator,
+)
+
+
+def _env_bool(name: str, default: bool = False) -> bool:
+    value = os.environ.get(name, "").strip().lower()
+    if not value:
+        return default
+    return value in {"1", "true", "yes", "on"}
 
 
 class GenerateUMLInput(BaseModel):
@@ -18,30 +34,42 @@ class GenerateUMLInput(BaseModel):
 
     diagram_type: str = Field(
         ...,
-        description="Type of diagram (e.g. class, sequence, activity, mermaid, d2). See uml://types.",
+        description=(
+            "Diagram type such as class, sequence, mermaid, d2, or graphviz. "
+            "Use list_diagram_types when unsure."
+        ),
         min_length=1,
     )
     code: str = Field(
         ...,
-        description="Diagram code in the format for the chosen type",
+        description="Diagram source code in the syntax required by diagram_type.",
         min_length=1,
     )
     output_dir: Optional[str] = Field(
         default=None,
-        description="Directory to save the image; omit for URL/base64 only (no file write)",
+        description=(
+            "Local directory to save the rendered file. Omit for URL/base64 output. "
+            "Hosted/read-only deployments reject file output."
+        ),
     )
     output_format: str = Field(
         default="svg",
-        description="Output format: svg, png, pdf, jpeg, txt, or base64 (per diagram type; see uml://formats)",
+        description=(
+            "Requested output format: svg, png, pdf, jpeg, txt, or base64 when "
+            "supported by the selected diagram type."
+        ),
     )
     theme: Optional[str] = Field(
         default=None,
-        description="PlantUML theme (only for PlantUML diagram types)",
+        description="Optional PlantUML theme; ignored by non-PlantUML backends.",
     )
     scale: float = Field(
         default=1.0,
         ge=0.1,
-        description="Scale factor for SVG output (e.g. 2.0 doubles size). Only applied when output_format is svg.",
+        description=(
+            "SVG scale factor. For example, 2.0 doubles SVG dimensions. "
+            "Ignored for non-SVG output."
+        ),
     )
 
     @field_validator("diagram_type")
@@ -74,18 +102,18 @@ class GenerateUMLInput(BaseModel):
     @field_validator("output_format")
     @classmethod
     def validate_output_format(cls, v: str) -> str:
-        v = v.lower().strip()
+        value = v.lower().strip()
         allowed = ("svg", "png", "pdf", "jpeg", "txt", "base64")
-        if v not in allowed:
+        if value not in allowed:
             raise ValueError(f"output_format must be one of: {', '.join(allowed)}")
-        return v
+        return value
 
     @model_validator(mode="after")
     def validate_output_format_for_diagram_type(self) -> "GenerateUMLInput":
         from ..core.config import MCP_SETTINGS
 
-        diagram_type = getattr(self, "diagram_type", "").lower()
-        output_format = (getattr(self, "output_format", "") or "svg").lower().strip()
+        diagram_type = self.diagram_type.lower()
+        output_format = self.output_format.lower().strip()
         types_map = getattr(MCP_SETTINGS, "diagram_types", {})
         if diagram_type in types_map:
             allowed = types_map[diagram_type].formats
@@ -97,18 +125,50 @@ class GenerateUMLInput(BaseModel):
         return self
 
     @model_validator(mode="after")
-    def reject_output_dir_when_read_only(self) -> "GenerateUMLInput":
+    def validate_output_location(self) -> "GenerateUMLInput":
+        """Reject file writes in hosted mode and sandbox local writes by default."""
         from ..core.config import MCP_SETTINGS
 
-        if MCP_SETTINGS.read_only and self.output_dir:
+        if not self.output_dir:
+            return self
+
+        if MCP_SETTINGS.read_only or MCP_SETTINGS.memory_only:
             raise ValueError(
-                "output_dir is not allowed when MCP_READ_ONLY=true; omit output_dir for URL/base64 only."
+                "output_dir is not allowed in read-only or memory-only mode; "
+                "omit output_dir for URL/base64 output."
             )
+
+        # Existing tests and explicit developer test environments keep their historical
+        # arbitrary-path behavior. Normal local runs are sandboxed unless explicitly
+        # opted out with MCP_ALLOW_ARBITRARY_OUTPUT_DIR=true.
+        allow_arbitrary = _env_bool(
+            "MCP_ALLOW_ARBITRARY_OUTPUT_DIR",
+            default=_env_bool("TESTING", False),
+        )
+        if allow_arbitrary:
+            return self
+
+        root_raw = os.environ.get("MCP_OUTPUT_ROOT") or MCP_SETTINGS.output_dir
+        root = Path(root_raw).expanduser().resolve()
+        requested = Path(self.output_dir).expanduser()
+        if not requested.is_absolute():
+            requested = (Path.cwd() / requested).resolve()
+        else:
+            requested = requested.resolve()
+
+        try:
+            requested.relative_to(root)
+        except ValueError as exc:
+            raise ValueError(
+                f"output_dir must stay under configured output root '{root}'. "
+                "Set MCP_OUTPUT_ROOT to change the sandbox or explicitly opt out with "
+                "MCP_ALLOW_ARBITRARY_OUTPUT_DIR=true for trusted local development."
+            ) from exc
         return self
 
 
 class ValidateUMLInput(BaseModel):
-    """Input model for validate_uml tool (subset of generate_uml; no output_dir)."""
+    """Input model for validate_uml tool."""
 
     model_config = ConfigDict(
         str_strip_whitespace=True,
@@ -118,17 +178,17 @@ class ValidateUMLInput(BaseModel):
 
     diagram_type: str = Field(
         ...,
-        description="Type of diagram (e.g. class, sequence, mermaid, d2). See uml://types.",
+        description="Diagram type to validate. Use list_diagram_types when unsure.",
         min_length=1,
     )
     code: str = Field(
         ...,
-        description="Diagram code in the format for the chosen type",
+        description="Diagram source code to validate locally without rendering.",
         min_length=1,
     )
     output_format: str = Field(
         default="svg",
-        description="Output format: svg, png, pdf, jpeg, txt, or base64 (per diagram type; see uml://formats)",
+        description="Output format whose compatibility should be validated.",
     )
 
     @field_validator("diagram_type")
@@ -161,18 +221,18 @@ class ValidateUMLInput(BaseModel):
     @field_validator("output_format")
     @classmethod
     def validate_output_format(cls, v: str) -> str:
-        v = v.lower().strip()
+        value = v.lower().strip()
         allowed = ("svg", "png", "pdf", "jpeg", "txt", "base64")
-        if v not in allowed:
+        if value not in allowed:
             raise ValueError(f"output_format must be one of: {', '.join(allowed)}")
-        return v
+        return value
 
     @model_validator(mode="after")
     def validate_output_format_for_diagram_type(self) -> "ValidateUMLInput":
         from ..core.config import MCP_SETTINGS
 
-        diagram_type = getattr(self, "diagram_type", "").lower()
-        output_format = (getattr(self, "output_format", "") or "svg").lower().strip()
+        diagram_type = self.diagram_type.lower()
+        output_format = self.output_format.lower().strip()
         types_map = getattr(MCP_SETTINGS, "diagram_types", {})
         if diagram_type in types_map:
             allowed = types_map[diagram_type].formats
@@ -184,41 +244,133 @@ class ValidateUMLInput(BaseModel):
         return self
 
 
+class RenderAttempt(BaseModel):
+    """One renderer attempt in the generation pipeline."""
+
+    backend: str
+    ok: Optional[bool] = None
+    status: Optional[str] = None
+    duration_ms: Optional[float] = None
+    error_summary: Optional[str] = None
+    error_code: Optional[str] = None
+    retry_count: int = 0
+
+
+class DiagramError(BaseModel):
+    """Machine-readable detail for a failed diagram request."""
+
+    code: str
+    message: str
+    diagram_type: Optional[str] = None
+    backend: Optional[str] = None
+    retryable: bool = False
+    line: Optional[int] = None
+    column: Optional[int] = None
+    suggestion: Optional[str] = None
+
+
 class DiagramResult(BaseModel):
     """Structured output for diagram generation tools."""
 
     code: str
+    success: Optional[bool] = None
+    diagram_type: Optional[str] = None
+    output_format: Optional[str] = None
     url: Optional[str] = None
     playground: Optional[str] = None
     local_path: Optional[str] = None
-    content_base64: Optional[str] = (
-        None  # Image bytes when not writing to file (memory-only)
-    )
+    content_base64: Optional[str] = None
     error: Optional[str] = None
+    error_detail: Optional[DiagramError] = None
     source: Optional[str] = None
-    attempts: Optional[list] = None
+    attempts: Optional[list[RenderAttempt]] = None
     fallback_used: Optional[bool] = None
     render_ms: Optional[float] = None
     cache_hit: Optional[bool] = None
+    cache_lookup_ms: Optional[float] = None
     mime_type: Optional[str] = None
+
+
+class ValidationDiagnostic(BaseModel):
+    """Actionable local validation diagnostic."""
+
+    severity: str
+    code: str
+    message: str
+    line: Optional[int] = None
+    column: Optional[int] = None
+    suggestion: Optional[str] = None
 
 
 class ValidationResult(BaseModel):
     """Structured output for validate_uml."""
 
     valid: bool
-    errors: list[str] = []
-    warnings: list[str] = []
-    suggestions: list[str] = []
+    diagram_type: Optional[str] = None
+    backend: Optional[str] = None
+    errors: list[str] = Field(default_factory=list)
+    warnings: list[str] = Field(default_factory=list)
+    suggestions: list[str] = Field(default_factory=list)
+    diagnostics: list[ValidationDiagnostic] = Field(default_factory=list)
+    corrected_code: Optional[str] = None
+    prepared_code: Optional[str] = None
+    strict: bool = False
+    normalized: bool = False
+    changes: list[str] = Field(default_factory=list)
+
+
+class BatchDiagramItem(BaseModel):
+    """One indexed item returned by generate_uml_batch."""
+
+    index: int
+    code: Optional[str] = None
+    success: Optional[bool] = None
+    diagram_type: Optional[str] = None
+    output_format: Optional[str] = None
+    url: Optional[str] = None
+    playground: Optional[str] = None
+    local_path: Optional[str] = None
+    content_base64: Optional[str] = None
+    error: Optional[str] = None
+    error_detail: Optional[DiagramError] = None
+    source: Optional[str] = None
+    attempts: Optional[list[RenderAttempt]] = None
+    fallback_used: Optional[bool] = None
+    render_ms: Optional[float] = None
+    cache_hit: Optional[bool] = None
+    cache_lookup_ms: Optional[float] = None
+    mime_type: Optional[str] = None
 
 
 class BatchDiagramResult(BaseModel):
     """Structured output for generate_uml_batch."""
 
-    results: list[DiagramResult]
+    results: list[BatchDiagramItem] = Field(default_factory=list)
+    error: Optional[str] = None
 
 
-class DiagramTypesOutput(BaseModel):
-    """Structured output for list_diagram_types."""
+class DiagramTypeInfo(BaseModel):
+    """Metadata for one supported diagram type."""
 
-    types: dict[str, Any]
+    backend: str
+    description: str
+    formats: list[str]
+
+
+class DiagramTypesOutput(RootModel[dict[str, DiagramTypeInfo]]):
+    """Dynamic diagram type map returned by list_diagram_types."""
+
+
+__all__ = [
+    "BatchDiagramItem",
+    "BatchDiagramResult",
+    "DiagramError",
+    "DiagramResult",
+    "DiagramTypeInfo",
+    "DiagramTypesOutput",
+    "GenerateUMLInput",
+    "RenderAttempt",
+    "ValidateUMLInput",
+    "ValidationDiagnostic",
+    "ValidationResult",
+]

--- a/mcp_core/tools/tool_decorator.py
+++ b/mcp_core/tools/tool_decorator.py
@@ -1,17 +1,97 @@
-"""
-Decorator system for MCP tools
-"""
+"""Decorator system for MCP tools."""
+
+from __future__ import annotations
 
 import inspect
 import logging
+from functools import wraps
 from typing import Any, Callable, Dict, List, Optional, TypeVar, cast
 
 logger = logging.getLogger(__name__)
 
-# Store for registered tools when using decorator pattern
 _registered_tools: Dict[str, Dict[str, Any]] = {}
 
 F = TypeVar("F", bound=Callable[..., Any])
+
+
+def _normalize_output_schema(output_schema: Any) -> Optional[dict[str, Any]]:
+    """Convert a Pydantic model class or mapping to FastMCP's JSON Schema shape."""
+    if output_schema is None:
+        return None
+    if isinstance(output_schema, dict):
+        return output_schema
+    model_json_schema = getattr(output_schema, "model_json_schema", None)
+    if callable(model_json_schema):
+        schema = model_json_schema()
+        if isinstance(schema, dict):
+            return schema
+    raise TypeError(
+        "output_schema must be a JSON Schema dict or a Pydantic model class with model_json_schema()"
+    )
+
+
+def _summarize_tool_result(tool_name: str, result: dict[str, Any]) -> str:
+    """Build a compact LLM-facing summary without repeating large payload fields."""
+    if tool_name == "generate_uml":
+        return (
+            f"Generated {result.get('diagram_type') or 'diagram'} successfully. "
+            f"Renderer: {result.get('source') or 'unknown'}. "
+            f"Format: {result.get('output_format') or 'unknown'}. "
+            f"Render: {result.get('render_ms') if result.get('render_ms') is not None else 'n/a'} ms. "
+            f"Cache hit: {bool(result.get('cache_hit'))}."
+        )
+    if tool_name == "generate_uml_batch":
+        rows = result.get("results") or []
+        failures = sum(1 for row in rows if isinstance(row, dict) and row.get("error"))
+        return f"Processed {len(rows)} diagrams; {failures} failed."
+    if tool_name == "validate_uml":
+        state = "valid" if result.get("valid") else "invalid"
+        diagnostics = result.get("diagnostics") or []
+        return f"Diagram is {state}; {len(diagnostics)} diagnostic(s)."
+    if tool_name == "list_diagram_types":
+        return f"Returned {len(result)} supported diagram type(s)."
+    return "Tool completed successfully."
+
+
+def _as_mcp_tool_result(tool_name: str, result: Any) -> Any:
+    """Adapt legacy Python return values to first-class MCP structured results."""
+    if not isinstance(result, dict):
+        return result
+
+    if result.get("error"):
+        try:
+            from fastmcp.exceptions import ToolError
+        except ImportError as exc:  # pragma: no cover - package is required in production
+            raise RuntimeError(str(result["error"])) from exc
+        raise ToolError(str(result["error"]))
+
+    try:
+        from fastmcp.tools import ToolResult
+        from mcp.types import ImageContent, TextContent
+    except ImportError:
+        # The mock server used in unit tests does not need protocol result objects.
+        return result
+
+    content: list[Any] = [
+        TextContent(type="text", text=_summarize_tool_result(tool_name, result))
+    ]
+    mime_type = str(result.get("mime_type") or "").lower()
+    image_data = result.get("content_base64")
+    if image_data and mime_type in {"image/png", "image/jpeg"}:
+        content.append(
+            ImageContent(type="image", data=str(image_data), mimeType=mime_type)
+        )
+
+    meta: dict[str, Any] = {}
+    for key in ("render_ms", "cache_hit", "fallback_used", "source"):
+        if key in result and result[key] is not None:
+            meta[key] = result[key]
+
+    return ToolResult(
+        content=content,
+        structured_content=result,
+        meta=meta or None,
+    )
 
 
 def mcp_tool(
@@ -23,37 +103,15 @@ def mcp_tool(
     annotations: Optional[Dict[str, Any]] = None,
     output_schema: Optional[Any] = None,
 ) -> Callable[[F], F]:
-    """
-    Decorator for registering a function as an MCP tool.
-
-    Args:
-        name: Tool name (defaults to function name if not provided)
-        description: Tool description (defaults to function docstring if not provided)
-        category: Tool category for organization
-        required_params: List of required parameter names
-        example: Example usage of the tool
-        annotations: MCP tool hints (readOnlyHint, destructiveHint, idempotentHint, openWorldHint)
-        output_schema: Pydantic model or dict for FastMCP outputSchema
-
-    Returns:
-        Decorated function
-
-    Example:
-        @mcp_tool(description="Generate a class diagram", category="uml")
-        def generate_class_diagram(code: str, output_dir: str) -> Dict[str, Any]:
-            # Implementation
-            return {"code": code, "url": "..."}
-    """
+    """Decorator for registering a function as an MCP tool."""
 
     def decorator(func: F) -> F:
         func_name = name or getattr(func, "__name__", "tool")
         func_doc = inspect.getdoc(func) or ""
-        func_description = description or func_doc.split("\n")[0] if func_doc else ""
+        func_description = description or (func_doc.split("\n")[0] if func_doc else "")
 
-        # Get parameter annotations from function signature
         sig = inspect.signature(func)
-        param_info = {}
-
+        param_info: dict[str, dict[str, Any]] = {}
         for param_name, param in sig.parameters.items():
             param_type = (
                 param.annotation
@@ -63,7 +121,6 @@ def mcp_tool(
             param_default = (
                 None if param.default is inspect.Parameter.empty else param.default
             )
-
             param_info[param_name] = {
                 "type": (
                     param_type.__name__
@@ -74,7 +131,6 @@ def mcp_tool(
                 "default": param_default,
             }
 
-        # Store tool metadata
         _registered_tools[func_name] = {
             "function": func,
             "name": func_name,
@@ -92,108 +148,97 @@ def mcp_tool(
                 else None
             ),
         }
-
-        # Return function unchanged
         return cast(F, func)
 
     return decorator
 
 
 def register_tools_with_server(server: Any) -> List[str]:
-    """
-    Register all decorated tools with the MCP server
+    """Register all decorated tools with the MCP server."""
+    logger.info("Registering %s tools with the MCP server", len(_registered_tools))
 
-    Args:
-        server: The MCP server instance
-
-    Returns:
-        List of registered tool names
-    """
-    logger.info(f"Registering {len(_registered_tools)} tools with the MCP server")
-
-    registered_tools = []
+    registered_tools: list[str] = []
     server_any = cast(Any, server)
 
     for tool_name, tool_info in _registered_tools.items():
         func = tool_info["function"]
         annotations = tool_info.get("annotations") or {}
-        output_schema = tool_info.get("output_schema")
+        output_schema = _normalize_output_schema(tool_info.get("output_schema"))
 
-        # Build tool registration kwargs
-        tool_kwargs = {"name": tool_name, "description": tool_info["description"]}
+        @wraps(func)
+        def protocol_func(*args: Any, __func: Callable[..., Any] = func, __name: str = tool_name, **kwargs: Any) -> Any:
+            return _as_mcp_tool_result(__name, __func(*args, **kwargs))
+
+        tool_kwargs: dict[str, Any] = {
+            "name": tool_name,
+            "description": tool_info["description"],
+        }
         if annotations:
             tool_kwargs["annotations"] = annotations
         if output_schema is not None:
             tool_kwargs["output_schema"] = output_schema
 
-        # Register with server (handle different server APIs)
         try:
             dec = server_any.tool(**tool_kwargs)
-            dec(func)
+            dec(protocol_func)
         except TypeError:
+            # Compatibility path for older/mock server APIs. The project is pinned to
+            # FastMCP 4 in production, but tests intentionally exercise a minimal mock.
             try:
-                # Try without annotations (server may not support them)
                 dec = server_any.tool(
-                    name=tool_name, description=tool_info["description"]
+                    name=tool_name,
+                    description=tool_info["description"],
                 )
-                dec(func)
+                dec(protocol_func)
             except TypeError:
                 try:
-                    # Try just passing the description (alternate style)
                     dec = server_any.tool(tool_info["description"])
-                    dec(func)
+                    dec(protocol_func)
                 except TypeError:
-                    # Fallback to simple decorator with no args (basic style)
-                    server_any.tool(func)
+                    server_any.tool(protocol_func)
 
-                # If that didn't throw an error but we need to rename the function
-                if tool_name != func.__name__:
-                    # Use the _tools dictionary directly if we can access it
+                if tool_name != protocol_func.__name__:
                     if hasattr(server, "_tools"):
                         tools_map: Any = getattr(server, "_tools")
-                        tools_map[tool_name] = tools_map.pop(func.__name__, func)
+                        tools_map[tool_name] = tools_map.pop(
+                            protocol_func.__name__, protocol_func
+                        )
                     else:
                         logger.warning(
-                            f"Could not rename tool '{func.__name__}' to '{tool_name}' - server API doesn't support it"
+                            "Could not rename tool '%s' to '%s'; server API does not support it",
+                            protocol_func.__name__,
+                            tool_name,
                         )
 
         registered_tools.append(tool_name)
-        logger.debug(f"Registered tool: {tool_name}")
+        logger.debug("Registered tool: %s", tool_name)
 
     return registered_tools
 
 
 def get_tool_registry() -> Dict[str, Dict[str, Any]]:
-    """
-    Get the registry of all tools registered with the decorator
-
-    Returns:
-        Dictionary of tool metadata
-    """
+    """Get information about all registered tools."""
     return _registered_tools
 
 
 def get_tool_categories() -> Dict[str, List[str]]:
-    """
-    Get tools organized by category
-
-    Returns:
-        Dictionary mapping categories to tool names
-    """
+    """Get tools organized by category."""
     categories: Dict[str, List[str]] = {}
-
     for tool_name, tool_info in _registered_tools.items():
         category = tool_info["category"]
-        if category not in categories:
-            categories[category] = []
-
-        categories[category].append(tool_name)
-
+        categories.setdefault(category, []).append(tool_name)
     return categories
 
 
-def clear_tool_registry():
-    """
-    Clear the tool registry (mainly for testing)
-    """
+def clear_tool_registry() -> None:
+    """Clear the tool registry (mainly for testing)."""
     _registered_tools.clear()
+
+
+__all__ = [
+    "clear_tool_registry",
+    "get_tool_categories",
+    "get_tool_registry",
+    "mcp_tool",
+    "register_tools_with_server",
+]

--- a/mcp_core/tools/tool_decorator.py
+++ b/mcp_core/tools/tool_decorator.py
@@ -79,7 +79,7 @@ def _as_mcp_tool_result(tool_name: str, result: Any) -> Any:
     image_data = result.get("content_base64")
     if image_data and mime_type in {"image/png", "image/jpeg"}:
         content.append(
-            ImageContent(type="image", data=str(image_data), mimeType=mime_type)
+            ImageContent(type="image", data=str(image_data), mime_type=mime_type)
         )
 
     meta: dict[str, Any] = {}

--- a/tests/test_mcp_hardening.py
+++ b/tests/test_mcp_hardening.py
@@ -1,0 +1,190 @@
+"""Regression tests for MCP result contracts, caching, security, and discovery."""
+
+from __future__ import annotations
+
+import os
+import time
+from unittest.mock import patch
+
+import pytest
+
+from mcp_core.core import server as server_module
+from mcp_core.core.config import MCP_SETTINGS
+from mcp_core.core.render_cache import get_render_cache
+from mcp_core.tools.diagram_tools import (
+    generate_uml,
+    generate_uml_batch,
+    list_diagram_types,
+    validate_uml,
+)
+from mcp_core.tools.schemas import DiagramResult, DiagramTypesOutput, GenerateUMLInput
+from mcp_core.tools.tool_decorator import _normalize_output_schema
+
+
+@pytest.fixture(autouse=True)
+def _clear_render_cache():
+    cache = get_render_cache()
+    cache.clear()
+    yield
+    cache.clear()
+
+
+def test_pydantic_output_schema_is_converted_to_json_schema():
+    schema = _normalize_output_schema(DiagramResult)
+    assert schema is not None
+    assert schema["type"] == "object"
+    assert "properties" in schema
+    assert "code" in schema["properties"]
+    assert "cache_hit" in schema["properties"]
+
+
+def test_dynamic_diagram_type_schema_matches_raw_map_shape():
+    schema = _normalize_output_schema(DiagramTypesOutput)
+    assert schema is not None
+    assert schema["type"] == "object"
+    assert "additionalProperties" in schema
+
+
+def test_list_diagram_types_filters_without_breaking_zero_argument_shape():
+    all_types = list_diagram_types()
+    assert "class" in all_types
+
+    sequence_types = list_diagram_types(query="sequence")
+    assert "sequence" in sequence_types
+    assert all(
+        "sequence" in (
+            name + " " + info["description"] + " " + info["backend"]
+        ).lower()
+        for name, info in sequence_types.items()
+    )
+
+    plantuml_svg = list_diagram_types(backend="plantuml", output_format="svg", limit=2)
+    assert 1 <= len(plantuml_svg) <= 2
+    assert all(info["backend"] == "plantuml" for info in plantuml_svg.values())
+    assert all("svg" in info["formats"] for info in plantuml_svg.values())
+
+
+def test_validate_uml_returns_structured_diagnostics():
+    result = validate_uml(
+        "mermaid",
+        "sequenceDiagram\nA->>",
+        strict=True,
+    )
+    assert result["valid"] is False
+    assert result["diagnostics"]
+    diagnostic = result["diagnostics"][0]
+    assert diagnostic["severity"] == "error"
+    assert diagnostic["code"] == "MERMAID_DANGLING_ARROW"
+    assert diagnostic["line"] == 2
+
+
+def test_validate_uml_reports_deterministic_normalization():
+    result = validate_uml("class", "class A")
+    assert result["valid"] is True
+    assert result["normalized"] is True
+    assert "added @startuml wrapper" in result["changes"]
+    assert "added @enduml wrapper" in result["changes"]
+    assert result["corrected_code"].startswith("@startuml")
+
+
+def test_output_dir_is_sandboxed_when_arbitrary_paths_are_not_allowed(
+    monkeypatch, tmp_path
+):
+    root = tmp_path / "allowed"
+    root.mkdir()
+    monkeypatch.setenv("MCP_OUTPUT_ROOT", str(root))
+    monkeypatch.setenv("MCP_ALLOW_ARBITRARY_OUTPUT_DIR", "false")
+    monkeypatch.setattr(MCP_SETTINGS, "read_only", False)
+    monkeypatch.setattr(MCP_SETTINGS, "memory_only", False)
+
+    allowed = GenerateUMLInput(
+        diagram_type="class",
+        code="class A",
+        output_dir=str(root / "diagrams"),
+    )
+    assert allowed.output_dir
+
+    with pytest.raises(ValueError, match="configured output root"):
+        GenerateUMLInput(
+            diagram_type="class",
+            code="class A",
+            output_dir=str(tmp_path / "outside"),
+        )
+
+
+def test_generate_uml_uses_real_cache_when_enabled(monkeypatch):
+    monkeypatch.setenv("MCP_RENDER_CACHE_ENABLED", "true")
+    cache = get_render_cache()
+    cache.clear()
+
+    rendered = {
+        "code": "graph TD; A-->B;",
+        "url": "https://kroki.io/mermaid/svg/cache-test",
+        "playground": None,
+        "local_path": None,
+        "source": "kroki",
+        "render_ms": 12.5,
+        "mime_type": "image/svg+xml",
+    }
+    with patch("mcp_core.core.diagram_service.generate_diagram", return_value=rendered) as render:
+        first = generate_uml("mermaid", "graph TD; A-->B;")
+        second = generate_uml("mermaid", "graph TD; A-->B;")
+
+    assert render.call_count == 1
+    assert first["cache_hit"] is False
+    assert second["cache_hit"] is True
+    assert second["url"] == first["url"]
+    assert cache.stats()["hits"] >= 1
+
+
+def test_cache_key_changes_for_render_options(monkeypatch):
+    monkeypatch.setenv("MCP_RENDER_CACHE_ENABLED", "true")
+    cache = get_render_cache()
+    cache.clear()
+
+    rendered = {
+        "code": "@startuml\nclass A\n@enduml",
+        "url": "https://example.test/a.svg",
+        "playground": None,
+        "local_path": None,
+        "source": "kroki",
+    }
+    with patch("mcp_core.core.diagram_service.generate_diagram", return_value=rendered) as render:
+        generate_uml("class", "class A", scale=1.0)
+        generate_uml("class", "class A", scale=2.0)
+    assert render.call_count == 2
+
+
+def test_batch_keeps_input_order_under_concurrency(monkeypatch):
+    monkeypatch.setenv("MCP_BATCH_CONCURRENCY", "3")
+
+    def fake_render(index, raw, output_dir):
+        time.sleep((2 - index) * 0.01)
+        return {"index": index, "code": raw["code"], "success": True}
+
+    items = [
+        {"diagram_type": "mermaid", "code": "a"},
+        {"diagram_type": "mermaid", "code": "b"},
+        {"diagram_type": "mermaid", "code": "c"},
+    ]
+    with patch("mcp_core.tools.diagram_tools._render_batch_item", side_effect=fake_render):
+        result = generate_uml_batch(items)
+
+    assert [row["index"] for row in result["results"]] == [0, 1, 2]
+
+
+def test_fastmcp_security_env_mapping(monkeypatch):
+    for name in (
+        "FASTMCP_HTTP_ALLOWED_HOSTS",
+        "FASTMCP_HTTP_ALLOWED_ORIGINS",
+        "FASTMCP_HTTP_HOST_ORIGIN_PROTECTION",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+    monkeypatch.setenv("MCP_ALLOWED_HOSTS", "uml-mcp.vercel.app,localhost")
+    monkeypatch.setenv("MCP_ALLOWED_ORIGINS", '["https://example.test"]')
+    server_module._configure_fastmcp_http_security()
+
+    assert os.environ["FASTMCP_HTTP_HOST_ORIGIN_PROTECTION"] == "true"
+    assert "uml-mcp.vercel.app" in os.environ["FASTMCP_HTTP_ALLOWED_HOSTS"]
+    assert "https://example.test" in os.environ["FASTMCP_HTTP_ALLOWED_ORIGINS"]

--- a/tests/test_mcp_hardening.py
+++ b/tests/test_mcp_hardening.py
@@ -18,7 +18,10 @@ from mcp_core.tools.diagram_tools import (
     validate_uml,
 )
 from mcp_core.tools.schemas import DiagramResult, DiagramTypesOutput, GenerateUMLInput
-from mcp_core.tools.tool_decorator import _normalize_output_schema
+from mcp_core.tools.tool_decorator import (
+    _as_mcp_tool_result,
+    _normalize_output_schema,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -45,6 +48,43 @@ def test_dynamic_diagram_type_schema_matches_raw_map_shape():
     assert "additionalProperties" in schema
 
 
+def test_protocol_adapter_returns_structured_content_and_image():
+    from fastmcp.tools import ToolResult
+    from mcp.types import ImageContent, TextContent
+
+    payload = {
+        "code": "digraph { A -> B; }",
+        "success": True,
+        "diagram_type": "graphviz",
+        "output_format": "png",
+        "url": "https://example.test/graph.png",
+        "content_base64": "aW1hZ2U=",
+        "source": "kroki",
+        "render_ms": 9.5,
+        "cache_hit": False,
+        "mime_type": "image/png",
+    }
+    result = _as_mcp_tool_result("generate_uml", payload)
+
+    assert isinstance(result, ToolResult)
+    assert result.structured_content == payload
+    assert isinstance(result.content[0], TextContent)
+    assert any(isinstance(block, ImageContent) for block in result.content)
+    image = next(block for block in result.content if isinstance(block, ImageContent))
+    assert image.mime_type == "image/png"
+    assert result.meta["render_ms"] == 9.5
+
+
+def test_protocol_adapter_raises_tool_error_for_execution_failure():
+    from fastmcp.exceptions import ToolError
+
+    with pytest.raises(ToolError, match="renderer unavailable"):
+        _as_mcp_tool_result(
+            "generate_uml",
+            {"error": "renderer unavailable", "code": "class A"},
+        )
+
+
 def test_list_diagram_types_filters_without_breaking_zero_argument_shape():
     all_types = list_diagram_types()
     assert "class" in all_types
@@ -52,13 +92,16 @@ def test_list_diagram_types_filters_without_breaking_zero_argument_shape():
     sequence_types = list_diagram_types(query="sequence")
     assert "sequence" in sequence_types
     assert all(
-        "sequence" in (
-            name + " " + info["description"] + " " + info["backend"]
-        ).lower()
+        "sequence"
+        in (name + " " + info["description"] + " " + info["backend"]).lower()
         for name, info in sequence_types.items()
     )
 
-    plantuml_svg = list_diagram_types(backend="plantuml", output_format="svg", limit=2)
+    plantuml_svg = list_diagram_types(
+        backend="plantuml",
+        output_format="svg",
+        limit=2,
+    )
     assert 1 <= len(plantuml_svg) <= 2
     assert all(info["backend"] == "plantuml" for info in plantuml_svg.values())
     assert all("svg" in info["formats"] for info in plantuml_svg.values())
@@ -88,7 +131,8 @@ def test_validate_uml_reports_deterministic_normalization():
 
 
 def test_output_dir_is_sandboxed_when_arbitrary_paths_are_not_allowed(
-    monkeypatch, tmp_path
+    monkeypatch,
+    tmp_path,
 ):
     root = tmp_path / "allowed"
     root.mkdir()
@@ -126,7 +170,10 @@ def test_generate_uml_uses_real_cache_when_enabled(monkeypatch):
         "render_ms": 12.5,
         "mime_type": "image/svg+xml",
     }
-    with patch("mcp_core.core.diagram_service.generate_diagram", return_value=rendered) as render:
+    with patch(
+        "mcp_core.core.diagram_service.generate_diagram",
+        return_value=rendered,
+    ) as render:
         first = generate_uml("mermaid", "graph TD; A-->B;")
         second = generate_uml("mermaid", "graph TD; A-->B;")
 
@@ -149,7 +196,10 @@ def test_cache_key_changes_for_render_options(monkeypatch):
         "local_path": None,
         "source": "kroki",
     }
-    with patch("mcp_core.core.diagram_service.generate_diagram", return_value=rendered) as render:
+    with patch(
+        "mcp_core.core.diagram_service.generate_diagram",
+        return_value=rendered,
+    ) as render:
         generate_uml("class", "class A", scale=1.0)
         generate_uml("class", "class A", scale=2.0)
     assert render.call_count == 2
@@ -159,6 +209,7 @@ def test_batch_keeps_input_order_under_concurrency(monkeypatch):
     monkeypatch.setenv("MCP_BATCH_CONCURRENCY", "3")
 
     def fake_render(index, raw, output_dir):
+        del output_dir
         time.sleep((2 - index) * 0.01)
         return {"index": index, "code": raw["code"], "success": True}
 
@@ -167,7 +218,10 @@ def test_batch_keeps_input_order_under_concurrency(monkeypatch):
         {"diagram_type": "mermaid", "code": "b"},
         {"diagram_type": "mermaid", "code": "c"},
     ]
-    with patch("mcp_core.tools.diagram_tools._render_batch_item", side_effect=fake_render):
+    with patch(
+        "mcp_core.tools.diagram_tools._render_batch_item",
+        side_effect=fake_render,
+    ):
         result = generate_uml_batch(items)
 
     assert [row["index"] for row in result["results"]] == [0, 1, 2]


### PR DESCRIPTION
## Summary

Implements the first high-impact slice of the approved UML-MCP improvement plan while preserving the existing four tool names and current transports.

### MCP result contract
- Convert Pydantic output models to real JSON Schema before FastMCP registration.
- Fix `list_diagram_types` output schema so it matches the actual dynamic map result.
- Adapt successful protocol calls to FastMCP `ToolResult` with compact text + `structuredContent`.
- Return PNG/JPEG bytes as MCP `ImageContent` when available.
- Convert top-level tool failures to MCP `ToolError` at the protocol boundary while keeping direct Python calls backward-compatible.
- Add human-readable tool titles and model-oriented descriptions.

### Rendering performance
- Add bounded process-local TTL/LRU render cache with deterministic SHA-256 keys.
- Cache only memory/URL results, never file-producing requests.
- Make `cache_hit` real and expose cache lookup metadata.
- Add bounded concurrent batch generation (`MCP_BATCH_CONCURRENCY`, default 4) with deterministic output ordering and partial-failure isolation.

### Validation and discovery
- Add structured validation diagnostics with stable codes, severity, optional line information, and suggestions.
- Report deterministic source normalization (`normalized`, `changes`).
- Add optional `query`, `backend`, `output_format`, and `limit` filters to `list_diagram_types` while preserving its zero-argument behavior.

### Security / HTTP
- Add local output-path sandboxing via `MCP_OUTPUT_ROOT` with explicit trusted-development opt-out.
- Map `MCP_ALLOWED_HOSTS` / `MCP_ALLOWED_ORIGINS` to FastMCP 4's native Host/Origin protection.
- Default FastMCP protection to `auto` when no explicit allowlists are configured.
- Add `Retry-After` and rate-limit metadata headers while continuing to trust only the socket peer IP.

### Tests
Adds focused regression coverage for:
- output schema conversion
- dynamic catalog schema shape
- discovery filtering
- structured diagnostics
- normalization reporting
- output sandboxing
- cache hit/miss behavior
- batch ordering under concurrency
- FastMCP security environment mapping

## Compatibility
- Existing tool names are unchanged: `generate_uml`, `validate_uml`, `list_diagram_types`, `generate_uml_batch`.
- Existing direct Python function calls continue to return dictionaries.
- HTTP `/mcp`, stdio, Vercel, Docker, resources, and prompts are preserved.

## Follow-ups intentionally not mixed into this PR
- MCP Apps interactive diagram viewer
- CORS policy cleanup in the FastAPI REST surface
- distributed cache/rate limiter
- OpenTelemetry
- version-source unification / docs growth pass
