### PR TITLE
fix(mcp): allow Vercel public hosts through FastMCP guard

### DIFF
--- a/mcp_core/core/server.py
+++ b/mcp_core/core/server.py
@@ -11,6 +11,7 @@ import json
 import logging
 import os
 from typing import Any
+from urllib.parse import urlsplit
 
 # Default HTTP deployments to stateless transport semantics. This removes
 # Mcp-Session-Id affinity for legacy clients too, which is important for Vercel,
@@ -37,25 +38,59 @@ def _parse_env_list(value: str) -> list[str]:
     return [item.strip() for item in raw.split(",") if item.strip()]
 
 
-def _configure_fastmcp_http_security() -> None:
-    """Map UML-MCP security env vars to FastMCP's native request guard.
+def _host_from_urlish(value: str) -> str:
+    """Extract a hostname from a host or URL-like environment value."""
+    raw = value.strip()
+    if not raw:
+        return ""
+    parsed = urlsplit(raw if "://" in raw else f"https://{raw}")
+    return parsed.hostname or ""
 
-    With no explicit allowlists FastMCP uses ``auto`` protection, which protects
-    localhost-bound direct servers without breaking reverse-proxy/serverless hosts.
-    Providing MCP_ALLOWED_HOSTS and/or MCP_ALLOWED_ORIGINS enables strict checking.
+
+def _vercel_allowed_hosts() -> list[str]:
+    """Return the exact Vercel public hosts exposed for this deployment."""
+    hosts: list[str] = []
+    for name in (
+        "VERCEL_URL",
+        "VERCEL_BRANCH_URL",
+        "VERCEL_PROJECT_PRODUCTION_URL",
+    ):
+        host = _host_from_urlish(os.environ.get(name, ""))
+        if host and host not in hosts:
+            hosts.append(host)
+    return hosts
+
+
+def _configure_fastmcp_http_security() -> None:
+    """Configure FastMCP Host/Origin protection for direct and proxied HTTP.
+
+    Explicit MCP_ALLOWED_HOSTS / MCP_ALLOWED_ORIGINS remain authoritative. On
+    Vercel, append the exact deployment hosts supplied by Vercel so FastMCP does
+    not mistake the platform's loopback ASGI server address for a local-only
+    deployment and reject the public Host header with HTTP 421.
     """
     hosts = _parse_env_list(os.environ.get("MCP_ALLOWED_HOSTS", ""))
     origins = _parse_env_list(os.environ.get("MCP_ALLOWED_ORIGINS", ""))
 
+    if os.environ.get("VERCEL") == "1":
+        for host in _vercel_allowed_hosts():
+            if host not in hosts:
+                hosts.append(host)
+
     if hosts:
         os.environ["FASTMCP_HTTP_ALLOWED_HOSTS"] = json.dumps(hosts)
+    else:
+        os.environ.pop("FASTMCP_HTTP_ALLOWED_HOSTS", None)
+
     if origins:
         os.environ["FASTMCP_HTTP_ALLOWED_ORIGINS"] = json.dumps(origins)
+    else:
+        os.environ.pop("FASTMCP_HTTP_ALLOWED_ORIGINS", None)
 
     if hosts or origins:
         os.environ["FASTMCP_HTTP_HOST_ORIGIN_PROTECTION"] = "true"
     else:
-        os.environ.setdefault("FASTMCP_HTTP_HOST_ORIGIN_PROTECTION", "auto")
+        os.environ["FASTMCP_HTTP_HOST_ORIGIN_PROTECTION"] = "auto"
 
 
 _configure_fastmcp_http_security()

--- a/tests/test_vercel_host_security.py
+++ b/tests/test_vercel_host_security.py
@@ -1,0 +1,62 @@
+"""Regression tests for FastMCP Host protection behind Vercel."""
+
+from __future__ import annotations
+
+import json
+import os
+
+from mcp_core.core import server as server_module
+
+
+def _clear_security_env(monkeypatch) -> None:
+    for name in (
+        "FASTMCP_HTTP_ALLOWED_HOSTS",
+        "FASTMCP_HTTP_ALLOWED_ORIGINS",
+        "FASTMCP_HTTP_HOST_ORIGIN_PROTECTION",
+        "MCP_ALLOWED_HOSTS",
+        "MCP_ALLOWED_ORIGINS",
+        "VERCEL",
+        "VERCEL_URL",
+        "VERCEL_BRANCH_URL",
+        "VERCEL_PROJECT_PRODUCTION_URL",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+
+def test_vercel_hosts_are_added_to_fastmcp_allowlist(monkeypatch) -> None:
+    _clear_security_env(monkeypatch)
+    monkeypatch.setenv("VERCEL", "1")
+    monkeypatch.setenv(
+        "VERCEL_URL",
+        "uml-mcp-git-fix-vercel-mcp-host-421-antoinebou12.vercel.app",
+    )
+    monkeypatch.setenv("VERCEL_PROJECT_PRODUCTION_URL", "uml-mcp.vercel.app")
+
+    server_module._configure_fastmcp_http_security()
+
+    hosts = json.loads(os.environ["FASTMCP_HTTP_ALLOWED_HOSTS"])
+    assert "uml-mcp.vercel.app" in hosts
+    assert "uml-mcp-git-fix-vercel-mcp-host-421-antoinebou12.vercel.app" in hosts
+    assert os.environ["FASTMCP_HTTP_HOST_ORIGIN_PROTECTION"] == "true"
+
+
+def test_explicit_hosts_are_preserved_on_vercel(monkeypatch) -> None:
+    _clear_security_env(monkeypatch)
+    monkeypatch.setenv("VERCEL", "1")
+    monkeypatch.setenv("MCP_ALLOWED_HOSTS", "uml.example.com")
+    monkeypatch.setenv("VERCEL_URL", "uml-mcp.vercel.app")
+
+    server_module._configure_fastmcp_http_security()
+
+    hosts = json.loads(os.environ["FASTMCP_HTTP_ALLOWED_HOSTS"])
+    assert hosts == ["uml.example.com", "uml-mcp.vercel.app"]
+
+
+def test_non_vercel_without_allowlists_keeps_auto_protection(monkeypatch) -> None:
+    _clear_security_env(monkeypatch)
+
+    server_module._configure_fastmcp_http_security()
+
+    assert os.environ["FASTMCP_HTTP_HOST_ORIGIN_PROTECTION"] == "auto"
+    assert "FASTMCP_HTTP_ALLOWED_HOSTS" not in os.environ
+    assert "FASTMCP_HTTP_ALLOWED_ORIGINS" not in os.environ


### PR DESCRIPTION
## Description

Fixes the live `/mcp/` HTTP 421 `Misdirected Request` regression caused by FastMCP Host/Origin protection behind Vercel.

### Root cause
FastMCP 4 `auto` mode validates the `Host` header when the ASGI `scope.server` looks loopback. Vercel terminates the public request at its proxy and can expose a loopback server address to the app, so `Host: uml-mcp.vercel.app` was rejected against localhost-only defaults.

### Fix
- Preserve explicit `MCP_ALLOWED_HOSTS` / `MCP_ALLOWED_ORIGINS`.
- On Vercel, append exact public deployment hosts from `VERCEL_URL`, `VERCEL_BRANCH_URL`, and `VERCEL_PROJECT_PRODUCTION_URL`.
- Keep Host/Origin protection enabled instead of disabling it globally.
- Add regression tests for production/preview host derivation and non-Vercel auto mode.

## Type of change
- [x] Bug fix

## Checklist
- [x] Regression tests added
- [x] No dependency changes
- [x] No unrelated changes included

## Expected behavior
- `https://uml-mcp.vercel.app/mcp/` no longer returns 421.
- Preview deployment host is accepted.
- Unlisted Host headers remain rejected.