### PR TITLE
fix(mcp): improve advertised tool schemas

### DIFF
--- a/mcp_core/tools/diagram_tools.py
+++ b/mcp_core/tools/diagram_tools.py
@@ -54,9 +54,9 @@ def _bounded_limit(limit: Optional[int]) -> Optional[int]:
 
 @mcp_tool(
     description=(
-        "Find supported diagram types and their renderer/formats. Input optional query, "
-        "backend, output_format, and limit filters; returns matching type metadata. Use "
-        "this when you are unsure which diagram type or format to choose."
+        "Find supported diagram types and their renderer/formats. All filters are optional; "
+        "returns matching type metadata. Use this when you are unsure which diagram type "
+        "or format to choose."
     ),
     category="uml",
     example="list_diagram_types(query='sequence', output_format='svg')",
@@ -69,7 +69,14 @@ def list_diagram_types(
     output_format: Optional[str] = None,
     limit: Optional[int] = None,
 ) -> Dict[str, Any]:
-    """Return optionally filtered diagram type metadata."""
+    """Return optionally filtered diagram type metadata.
+
+    Args:
+        query: Optional text matched against type name, backend, and description.
+        backend: Optional renderer/backend name to match exactly.
+        output_format: Optional required output format such as svg or png.
+        limit: Optional maximum number of results, clamped to 1-100.
+    """
     logger.info(
         "Called list_diagram_types: query=%s backend=%s format=%s limit=%s",
         query,
@@ -186,7 +193,12 @@ def generate_uml_batch(
     items: List[Dict[str, Any]],
     output_dir: Optional[str] = None,
 ) -> Dict[str, Any]:
-    """Render multiple diagrams with bounded concurrency and stable ordering."""
+    """Render multiple diagrams with bounded concurrency and stable ordering.
+
+    Args:
+        items: Diagram request objects; each requires diagram_type and code.
+        output_dir: Optional shared local output directory for all rendered files.
+    """
     logger.info(
         "Called generate_uml_batch: count=%s, output_dir=%s",
         len(items) if items else 0,
@@ -234,7 +246,16 @@ def generate_uml(
     theme: Optional[str] = None,
     scale: float = 1.0,
 ) -> Dict[str, Any]:
-    """Generate a diagram using the specified diagram type."""
+    """Generate a diagram using the specified diagram type.
+
+    Args:
+        diagram_type: Supported diagram type, for example class, sequence, or mermaid.
+        code: Diagram source code in the syntax required by diagram_type.
+        output_dir: Optional local directory for the rendered file; omit on hosted deployments.
+        output_format: Requested output format, default svg.
+        theme: Optional PlantUML theme; ignored by non-PlantUML backends.
+        scale: SVG scale factor; ignored for non-SVG output.
+    """
     logger.info(
         "Called generate_uml tool: type=%s, code length=%s",
         diagram_type,
@@ -270,7 +291,14 @@ def validate_uml(
     output_format: str = "svg",
     strict: bool = False,
 ) -> Dict[str, Any]:
-    """Check inputs and light structure without rendering."""
+    """Check inputs and light structure without rendering.
+
+    Args:
+        diagram_type: Supported diagram type to validate.
+        code: Diagram source code to validate locally without rendering.
+        output_format: Output format whose compatibility should be checked.
+        strict: Enable additional syntax checks when supported.
+    """
     logger.info(
         "Called validate_uml tool: type=%s, code length=%s, strict=%s",
         diagram_type,

--- a/tests/test_mcp_tool_contracts.py
+++ b/tests/test_mcp_tool_contracts.py
@@ -1,0 +1,118 @@
+"""Regression tests for agent-facing MCP tool contracts."""
+
+from __future__ import annotations
+
+from fastmcp.tools.function_parsing import ParsedFunction
+
+from mcp_core.tools import diagram_tools
+from mcp_core.tools.schemas import (
+    BatchDiagramResult,
+    DiagramResult,
+    DiagramTypesOutput,
+    ValidationResult,
+)
+
+
+def _input_schema(fn):
+    return ParsedFunction.from_function(fn).input_schema
+
+
+def test_list_diagram_types_schema_describes_all_optional_filters() -> None:
+    schema = _input_schema(diagram_tools.list_diagram_types)
+    props = schema["properties"]
+
+    assert set(props) == {"query", "backend", "output_format", "limit"}
+    assert all(props[name].get("description") for name in props)
+    # All discovery filters are intentionally optional. JSON Schema may omit
+    # `required` entirely when the set is empty; both forms mean the same thing.
+    assert schema.get("required", []) == []
+
+
+def test_generate_uml_schema_describes_parameters_and_required_fields() -> None:
+    schema = _input_schema(diagram_tools.generate_uml)
+    props = schema["properties"]
+
+    assert set(props) == {
+        "diagram_type",
+        "code",
+        "output_dir",
+        "output_format",
+        "theme",
+        "scale",
+    }
+    assert all(props[name].get("description") for name in props)
+    assert set(schema.get("required", [])) == {"diagram_type", "code"}
+
+
+def test_validate_uml_schema_describes_parameters_and_required_fields() -> None:
+    schema = _input_schema(diagram_tools.validate_uml)
+    props = schema["properties"]
+
+    assert set(props) == {"diagram_type", "code", "output_format", "strict"}
+    assert all(props[name].get("description") for name in props)
+    assert set(schema.get("required", [])) == {"diagram_type", "code"}
+
+
+def test_generate_uml_batch_schema_describes_parameters_and_required_fields() -> None:
+    schema = _input_schema(diagram_tools.generate_uml_batch)
+    props = schema["properties"]
+
+    assert set(props) == {"items", "output_dir"}
+    assert all(props[name].get("description") for name in props)
+    assert schema.get("required", []) == ["items"]
+
+
+def test_list_diagram_types_response_matches_declared_output_schema() -> None:
+    result = diagram_tools.list_diagram_types(limit=2)
+    parsed = DiagramTypesOutput.model_validate(result)
+    assert len(parsed.root) <= 2
+
+
+def test_validate_uml_response_matches_declared_output_schema() -> None:
+    result = diagram_tools.validate_uml(
+        "class",
+        "@startuml\nclass A\n@enduml",
+        "svg",
+    )
+    parsed = ValidationResult.model_validate(result)
+    assert isinstance(parsed.valid, bool)
+
+
+def test_generate_uml_response_matches_declared_output_schema(monkeypatch) -> None:
+    expected = {
+        "code": "graph TD; A-->B;",
+        "success": True,
+        "diagram_type": "mermaid",
+        "output_format": "svg",
+        "url": "https://example.test/diagram.svg",
+        "source": "test",
+        "cache_hit": False,
+        "mime_type": "image/svg+xml",
+    }
+    monkeypatch.setattr(diagram_tools, "generate_from_request", lambda _request: expected)
+
+    result = diagram_tools.generate_uml("mermaid", expected["code"])
+    parsed = DiagramResult.model_validate(result)
+    assert parsed.success is True
+
+
+def test_generate_uml_batch_response_matches_declared_output_schema(monkeypatch) -> None:
+    def fake_generate(request):
+        return {
+            "code": request.code,
+            "success": True,
+            "diagram_type": request.diagram_type,
+            "output_format": request.output_format,
+            "url": "https://example.test/diagram.svg",
+            "source": "test",
+            "cache_hit": False,
+            "mime_type": "image/svg+xml",
+        }
+
+    monkeypatch.setattr(diagram_tools, "generate_from_request", fake_generate)
+    result = diagram_tools.generate_uml_batch(
+        [{"diagram_type": "mermaid", "code": "graph TD; A-->B;"}]
+    )
+    parsed = BatchDiagramResult.model_validate(result)
+    assert len(parsed.results) == 1
+    assert parsed.results[0].success is True


### PR DESCRIPTION
Improves agent-facing MCP tool contracts without changing tool names or call semantics.

- Adds concise Google-style parameter descriptions to all four tool functions so FastMCP 4.0.0b3 advertises them in inputSchema.
- Keeps list_diagram_types filters optional; its missing `required` array is semantically equivalent to `required: []`.
- Adds regression tests for descriptions and required fields.
- Adds response-contract tests validating all four tool outputs against their declared Pydantic output schemas.

This addresses the MCP inspector warnings about undescribed parameters and output-schema confidence while preserving backward compatibility.