### PR TITLE
test: repair three stale assertions against current runtime behavior

### DIFF
--- a/tests/test_core_utils.py
+++ b/tests/test_core_utils.py
@@ -77,8 +77,11 @@ def test_generate_diagram_exception(mock_kroki_client):
     assert "Test error" in result["error"]
 
 
-def test_output_directory_creation(tmp_path):
+def test_output_directory_creation(tmp_path, monkeypatch):
     """Test that the output directory is created if it doesn't exist."""
+    # Absolute output_dir outside MCP_OUTPUT_ROOT needs the explicit opt-in
+    # enforced by mcp_core.core.utils._sanitize_output_dir.
+    monkeypatch.setenv("MCP_ALLOW_ARBITRARY_OUTPUT_DIR", "true")
     non_existent_dir = os.path.join(tmp_path, "new_dir")
 
     # Directory shouldn't exist initially

--- a/tests/test_deployment_config.py
+++ b/tests/test_deployment_config.py
@@ -16,7 +16,10 @@ def test_pyproject_is_canonical_mcp_2026_manifest() -> None:
     project = pyproject["project"]
     dependencies = project["dependencies"]
 
-    assert "fastmcp-slim[server]==4.0.0b3" in dependencies
+    # Pinned exactly (Renovate bumps the patch); the major must stay on FastMCP 4.
+    assert any(
+        dependency.startswith("fastmcp-slim[server]==4.") for dependency in dependencies
+    )
     assert all(not dependency.startswith("fastmcp[tasks]") for dependency in dependencies)
     assert "mcp>=2.0.0,<3.0.0" in dependencies
     assert "fastapi>=0.141.1,<0.200.0" in dependencies

--- a/tests/test_diagram_tools.py
+++ b/tests/test_diagram_tools.py
@@ -28,10 +28,8 @@ class TestDiagramTools:
                 output_dir="/tmp/out",
             )
             assert "error" in result
-            assert (
-                "read_only" in result["error"].lower()
-                or "mcp_read_only" in result["error"].lower()
-            )
+            error = result["error"].lower()
+            assert "read-only" in error or "read_only" in error
         finally:
             config.MCP_SETTINGS.read_only = original
 


### PR DESCRIPTION
## Why

`main` currently fails `uv run pytest` with three unrelated-to-each-other stale assertions. This blocks any feature branch from showing a green suite, so this lands first as a pre-requisite.

## What

Test-only. No runtime code, no dependencies, no config touched.

| Test | Problem | Fix |
|---|---|---|
| `tests/test_deployment_config.py` | Asserted the literal `fastmcp-slim[server]==4.0.0b3`; `pyproject.toml` pins `==4.0.0` after Renovate bump a7619bd | Assert the *pin shape* — exact `==` on the FastMCP 4 major — so future patch bumps do not re-break it |
| `tests/test_core_utils.py::test_output_directory_creation` | Passes an absolute `tmp_path`, which `_sanitize_output_dir` now rejects without `MCP_ALLOW_ARBITRARY_OUTPUT_DIR` | `monkeypatch.setenv(...)` so the test exercises directory creation as intended |
| `tests/test_diagram_tools.py::...read_only` | Looked for `read_only` in the error; the validator emits `read-only` | Accept both spellings |

## Verification

```
uv run pytest    ->  439 passed  (was 437 passed, 2 failed + 1 more once the first was fixed)
```

## Note, out of scope

`uv run ruff check .` reports 371 pre-existing errors on `main` with ruff 0.16.x (0.16 broadened the default rule set; the last green CI run on `main` predates it). That is untouched here and deserves its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)