### PR TITLE
feat(docker): add opt-in local PlantUML compose profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,13 @@ docker build -t uml-mcp . && docker run -p 8000:8000 uml-mcp
 
 # stdio MCP subprocess mode
 docker run -i uml-mcp python server.py --transport stdio
+
+# Optional: add a local PlantUML server (opt-in profile, host port 8002)
+docker compose --profile plantuml up -d
 ```
+
+PlantUML is a fallback renderer, so set `MCP_DIAGRAM_FALLBACK=true` alongside the profile for
+UML-MCP to use it. See [docs/deploy/docker.md](docs/deploy/docker.md).
 
 ## Configuration (Local runtime)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,8 +14,10 @@ services:
       - MCP_OUTPUT_DIR=/app/output
       - USE_LOCAL_KROKI=true
       - KROKI_SERVER=http://kroki:8000
-      - MCP_DIAGRAM_FALLBACK=false
+      - MCP_DIAGRAM_FALLBACK=${MCP_DIAGRAM_FALLBACK:-false}
       - FASTMCP_STATELESS_HTTP=true
+      - USE_LOCAL_PLANTUML=${USE_LOCAL_PLANTUML:-false}
+      - PLANTUML_SERVER=${PLANTUML_SERVER:-http://plantuml-server:8080}
     healthcheck:
       test: ["CMD", "curl", "-fsS", "http://127.0.0.1:8000/health"]
       interval: 30s
@@ -23,9 +25,17 @@ services:
       retries: 3
       start_period: 20s
     depends_on:
-      - kroki
-      - blockdiag
-      - mermaid
+      kroki:
+        condition: service_started
+      blockdiag:
+        condition: service_started
+      mermaid:
+        condition: service_started
+      # Only present under `--profile plantuml`; a plain `docker compose up`
+      # starts the same three services it always has.
+      plantuml-server:
+        condition: service_started
+        required: false
     restart: unless-stopped
 
   kroki:
@@ -43,6 +53,23 @@ services:
 
   blockdiag:
     image: yuzutech/kroki-blockdiag
+    restart: unless-stopped
+
+  # Opt-in only: `docker compose --profile plantuml up -d`.
+  # PlantUML is a *fallback* renderer, so also set MCP_DIAGRAM_FALLBACK=true to
+  # let UML-MCP reach for it when Kroki cannot render a PlantUML-family diagram.
+  plantuml-server:
+    image: plantuml/plantuml-server:jetty-v1.2026.6
+    profiles:
+      - plantuml
+    ports:
+      - "8002:8080"
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:8080/"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
     restart: unless-stopped
 
 volumes:

--- a/docs/deploy/docker.md
+++ b/docs/deploy/docker.md
@@ -28,6 +28,49 @@ Stop the stack:
 docker compose down
 ```
 
+## Optional local PlantUML
+
+The compose file ships a `plantuml-server` service behind an opt-in profile, so it is not
+started by a plain `docker compose up`:
+
+```bash
+docker compose --profile plantuml up -d
+```
+
+That adds one container, `plantuml/plantuml-server:jetty-v1.2026.6`, published on host port
+`8002` (`8000` and `8001` are already taken by `uml-mcp` and `kroki`). It has an HTTP health
+check, so `docker compose ps` reports `healthy` once Jetty is serving.
+
+### Making UML-MCP actually use it
+
+PlantUML is a **fallback** renderer: UML-MCP tries Kroki first and only reaches for PlantUML
+when Kroki fails (see [Fallback strategy](../fallback-mechanism.md)). The compose stack runs
+with a local Kroki and therefore disables the fallback chain by default. Starting the profile
+on its own changes nothing about how diagrams are rendered — you also need to turn the chain
+back on:
+
+```bash
+MCP_DIAGRAM_FALLBACK=true USE_LOCAL_PLANTUML=true docker compose --profile plantuml up -d
+```
+
+`USE_LOCAL_PLANTUML`, `PLANTUML_SERVER` and `MCP_DIAGRAM_FALLBACK` are passed through from
+your shell with the previous defaults (`false`, `http://plantuml-server:8080`, `false`), so
+omitting them leaves today's behavior exactly as it was.
+
+A successful PlantUML render reports `"source": "plantuml_server"` in the tool response.
+
+### Fully offline
+
+Local Kroki plus local PlantUML means no outbound calls for any supported diagram type:
+
+```bash
+MCP_DIAGRAM_FALLBACK=true USE_LOCAL_PLANTUML=true docker compose --profile plantuml up -d
+```
+
+Without the profile, the `PLANTUML_SERVER` default points at a `plantuml-server` host that
+does not exist in the default stack — so the fallback simply fails and the Kroki error is
+returned, which is the current behavior.
+
 ## API + MCP only (public Kroki)
 
 If you don't need a local Kroki and want a single small image:
@@ -56,7 +99,7 @@ The Docker image reads the same variables as the local server. The most useful f
 | Variable | Description | Default |
 | --- | --- | --- |
 | `KROKI_SERVER` | Kroki gateway URL | `https://kroki.io` |
-| `PLANTUML_SERVER` | PlantUML server URL (fallback) | `http://plantuml-server:8080` |
+| `PLANTUML_SERVER` | PlantUML server URL (fallback); resolves to the `plantuml` profile service | `http://plantuml-server:8080` |
 | `USE_LOCAL_KROKI` | Use a local Kroki instance (`true`/`false`) | `false` |
 | `USE_LOCAL_PLANTUML` | Use a local PlantUML instance (`true`/`false`) | `false` |
 | `MCP_OUTPUT_DIR` | Where to write rendered diagrams | `./output` |

--- a/tests/test_compose_profiles.py
+++ b/tests/test_compose_profiles.py
@@ -1,0 +1,122 @@
+"""Contract tests for docker-compose.yml.
+
+The point of the `plantuml` profile is that it changes nothing until you ask for
+it, so these assert the default stack is byte-for-byte the same set of services
+and environment it has always been, and that the opt-in service is pinned and
+health-checked.
+"""
+
+from pathlib import Path
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+ROOT = Path(__file__).resolve().parents[1]
+PLANTUML_IMAGE = "plantuml/plantuml-server:jetty-v1.2026.6"
+
+
+@pytest.fixture(scope="module")
+def compose() -> dict:
+    return yaml.safe_load((ROOT / "docker-compose.yml").read_text(encoding="utf-8"))
+
+
+@pytest.fixture(scope="module")
+def services(compose: dict) -> dict:
+    return compose["services"]
+
+
+def _environment(service: dict) -> dict[str, str]:
+    """Compose list-form environment (`KEY=value`) as a mapping."""
+    entries = service["environment"]
+    if isinstance(entries, dict):
+        return {key: str(value) for key, value in entries.items()}
+    return dict(entry.split("=", 1) for entry in entries)
+
+
+def test_default_stack_is_unchanged(services: dict) -> None:
+    default = {
+        name for name, service in services.items() if not service.get("profiles")
+    }
+    assert default == {"uml-mcp", "kroki", "mermaid", "blockdiag"}
+
+
+def test_plantuml_server_is_opt_in_and_pinned(services: dict) -> None:
+    plantuml = services["plantuml-server"]
+
+    assert plantuml["profiles"] == ["plantuml"]
+    assert plantuml["image"] == PLANTUML_IMAGE
+    # A floating tag would silently change the renderer under users.
+    assert not plantuml["image"].endswith((":latest", ":jetty"))
+
+
+def test_plantuml_server_has_an_http_health_check(services: dict) -> None:
+    healthcheck = services["plantuml-server"]["healthcheck"]
+
+    # curl is verified present at /usr/bin/curl in the pinned image.
+    assert healthcheck["test"] == ["CMD", "curl", "-fsS", "http://127.0.0.1:8080/"]
+    assert healthcheck["retries"] >= 3
+    assert healthcheck["start_period"]
+
+
+def test_plantuml_server_does_not_collide_with_existing_ports(services: dict) -> None:
+    published = [
+        mapping.split(":")[0].strip('"')
+        for service in services.values()
+        for mapping in service.get("ports", [])
+    ]
+
+    assert "8002" in published
+    assert len(published) == len(set(published)), f"duplicate host ports: {published}"
+
+
+def test_uml_mcp_optional_dependency_keeps_the_default_startup(services: dict) -> None:
+    depends_on = services["uml-mcp"]["depends_on"]
+
+    assert set(depends_on) == {"kroki", "blockdiag", "mermaid", "plantuml-server"}
+    for name in ("kroki", "blockdiag", "mermaid"):
+        assert depends_on[name].get("required", True) is True
+    assert depends_on["plantuml-server"]["required"] is False
+
+
+def test_existing_uml_mcp_environment_is_preserved(services: dict) -> None:
+    environment = _environment(services["uml-mcp"])
+
+    assert environment["MCP_OUTPUT_DIR"] == "/app/output"
+    assert environment["USE_LOCAL_KROKI"] == "true"
+    assert environment["KROKI_SERVER"] == "http://kroki:8000"
+    assert environment["FASTMCP_STATELESS_HTTP"] == "true"
+
+
+def test_new_environment_passthrough_defaults_to_current_behaviour(
+    services: dict,
+) -> None:
+    """Overridable from the shell, but identical to today when left alone.
+
+    The defaults mirror mcp_core/core/config.py: USE_LOCAL_PLANTUML off,
+    PLANTUML_SERVER at the compose service name, fallback chain disabled because
+    the stack runs a local Kroki.
+    """
+    environment = _environment(services["uml-mcp"])
+
+    assert environment["USE_LOCAL_PLANTUML"] == "${USE_LOCAL_PLANTUML:-false}"
+    assert (
+        environment["PLANTUML_SERVER"]
+        == "${PLANTUML_SERVER:-http://plantuml-server:8080}"
+    )
+    assert environment["MCP_DIAGRAM_FALLBACK"] == "${MCP_DIAGRAM_FALLBACK:-false}"
+
+
+def test_plantuml_server_default_resolves_to_the_compose_service(
+    services: dict,
+) -> None:
+    """The PLANTUML_SERVER default is a hostname, so the service must match it.
+
+    Renaming the service without updating the default would leave the fallback
+    pointing at a host that does not exist.
+    """
+    default = _environment(services["uml-mcp"])["PLANTUML_SERVER"]
+    host = default.split("//", 1)[1].split(":")[0]
+
+    assert host in services
+    assert host == "plantuml-server"


### PR DESCRIPTION
## Why

`PLANTUML_SERVER` already defaults to `http://plantuml-server:8080` — a hostname that **no service in the stack provides**. So the PlantUML fallback path, which the config and docs describe in detail, has never had anything to talk to in Docker. This adds the service that default names, behind a profile so nothing changes until you ask for it.

(Idea from `hanifz-dr1/uml-mcp`; the config side was already upstream, only the container was missing.)

## What

```yaml
  plantuml-server:
    image: plantuml/plantuml-server:jetty-v1.2026.6
    profiles: [plantuml]
    ports: ["8002:8080"]
    healthcheck:
      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:8080/"]
```

- **Pinned tag**, not `:jetty` or `:latest` — a floating tag would swap the renderer under users. `jetty-v1.2026.6` is the current release (2026-06-08, amd64 + arm64).
- **Port 8002** — `8000` and `8001` are taken by `uml-mcp` and `kroki`.
- **`curl` verified present** at `/usr/bin/curl` in that exact image, not assumed.
- `uml-mcp` gains `USE_LOCAL_PLANTUML`, `PLANTUML_SERVER` and `MCP_DIAGRAM_FALLBACK` passthrough, **each defaulting to today's value**, plus an optional `depends_on` entry (`required: false`).

### The bit worth reading

PlantUML is only ever a **fallback** renderer, and this stack disables the fallback chain because it runs a local Kroki. **Starting the profile alone does not reroute anything** — you also need `MCP_DIAGRAM_FALLBACK=true`. Making that knob overridable (`${MCP_DIAGRAM_FALLBACK:-false}`) rather than flipping it is what keeps the default identical while making the profile actually usable. The docs say this outright rather than leaving people to discover it.

## Verification

```
docker compose config --services                  ->  blockdiag kroki mermaid uml-mcp        (unchanged)
docker compose --profile plantuml config --services ->  + plantuml-server
docker compose --profile plantuml up -d plantuml-server
docker compose ps                                 ->  Up (healthy) after ~15s, 0.0.0.0:8002->8080
curl http://localhost:8002/svg/<encoded>          ->  200
uv run pytest tests/test_compose_profiles.py      ->  8 passed
uv run pytest                                     ->  444 passed, 3 failed (pre-existing, see below)
MKDOCS_SOCIAL=false uv run mkdocs build --strict  ->  built
```

End-to-end through UML-MCP, with Kroki pointed at a dead port and the fallback enabled:

```
source  = plantuml_server
url     = http://localhost:8002/svg/SoWkIImgAStDuKhEIImkLd0kBIx9pqqjWdBzYrA0R9YWWgwk7LJ88J
bytes   = 4480
```

The 3 test failures are pre-existing on `main` and fixed by antoinebou12/uml-mcp#323.

## Not touched

The `kroki`, `mermaid` and `blockdiag` services, the `Dockerfile`, MCP tool schemas, `vercel.json`, `pyproject.toml`.

Heads-up unrelated to this PR: `docker build` runs `uv export --frozen`, which needs a `uv.lock`. That file is untracked in this repo, so an image build from a clean clone may fail. Left alone here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)