### PR TITLE
feat(integrations): add OI OS intent manifest

### DIFF
--- a/docs/integrations/oi_os.md
+++ b/docs/integrations/oi_os.md
@@ -1,0 +1,75 @@
+---
+title: OI OS
+description: "Community integration: route natural-language requests to UML-MCP tools through an OI OS intent manifest."
+tags:
+  - integrations
+  - community
+---
+
+# OI OS integration
+
+!!! note "Community integration"
+
+    This is metadata for a third-party agent runtime. It is maintained here as a
+    convenience and is not officially supported by the OI OS project.
+
+[OI OS](https://github.com/OI-OS) routes natural-language requests to MCP tools using an
+intent manifest. UML-MCP ships one as `oi-manifest.json` at the repository root.
+
+## Setup
+
+UML-MCP is consumed as an ordinary stdio MCP server — no OI-specific dependency, no fork, no
+changes to the Python package:
+
+```bash
+git clone https://github.com/antoinebou12/uml-mcp
+cd uml-mcp
+uv sync
+uv run python server.py
+```
+
+Register it with your OI OS installation the way you register any stdio MCP server, and point
+the runtime at `oi-manifest.json` for intent routing.
+
+## What the manifest contains
+
+```json
+{
+  "server_name": "uml_mcp",
+  "version": "1.3.0",
+  "intents": [
+    { "keyword": "generate uml", "tool_name": "generate_uml", "priority": 10 }
+  ],
+  "parameter_extractors": {},
+  "reminder_message": "..."
+}
+```
+
+| Field | Purpose |
+|---|---|
+| `server_name` | Matches `MCPSettings.server_name`, so routing binds to the right server |
+| `version` | Kept in lockstep with `pyproject.toml`; a test fails if they drift |
+| `intents` | Keyword → tool mappings covering all four tools |
+| `parameter_extractors` | Intentionally empty — see below |
+| `reminder_message` | Guidance shown to the agent: which tool does what, and to render returned URLs as links |
+
+Intents cover every registered tool: `generate_uml` (generation), `validate_uml` (validation),
+`list_diagram_types` (type discovery) and `generate_uml_batch` (batch generation). Keywords are
+unique, so a request never routes ambiguously.
+
+## Why parameter extraction is empty
+
+Regex-based parameter extraction cannot safely reconstruct diagram source. The upstream OI OS
+fork extracted the `code` argument with a rule that deletes the literal words *generate*,
+*create*, *uml*, *diagram* and *plantuml* from the request — which quietly corrupts any valid
+PlantUML that happens to contain them, for example a class named `Diagram`.
+
+Building `diagram_type` and `code` is the MCP client's job. The tools already validate their own
+inputs and `validate_uml` will report syntax problems before you spend a render on them, so an
+agent that assembles arguments properly needs no extraction layer.
+
+## Related
+
+- [MCP tools reference](../api/tools.md)
+- [Configuration](../configuration.md)
+- [Installation](../installation.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -119,6 +119,7 @@ nav:
       - Claude Desktop: integrations/claude_desktop.md
       - Claude Code: integrations/claude_code.md
       - Cursor: integrations/cursor.md
+      - OI OS (community): integrations/oi_os.md
       - Fallback strategy: fallback-mechanism.md
   - Developers:
       - developers/index.md

--- a/oi-manifest.json
+++ b/oi-manifest.json
@@ -1,0 +1,22 @@
+{
+  "server_name": "uml_mcp",
+  "version": "1.3.0",
+  "intents": [
+    { "keyword": "generate uml", "tool_name": "generate_uml", "priority": 10 },
+    { "keyword": "create diagram", "tool_name": "generate_uml", "priority": 10 },
+    { "keyword": "draw diagram", "tool_name": "generate_uml", "priority": 10 },
+    { "keyword": "class diagram", "tool_name": "generate_uml", "priority": 10 },
+    { "keyword": "sequence diagram", "tool_name": "generate_uml", "priority": 10 },
+    { "keyword": "activity diagram", "tool_name": "generate_uml", "priority": 10 },
+    { "keyword": "mermaid diagram", "tool_name": "generate_uml", "priority": 10 },
+    { "keyword": "plantuml", "tool_name": "generate_uml", "priority": 9 },
+    { "keyword": "validate uml", "tool_name": "validate_uml", "priority": 10 },
+    { "keyword": "check diagram syntax", "tool_name": "validate_uml", "priority": 10 },
+    { "keyword": "list diagram types", "tool_name": "list_diagram_types", "priority": 10 },
+    { "keyword": "supported diagram types", "tool_name": "list_diagram_types", "priority": 9 },
+    { "keyword": "generate diagrams batch", "tool_name": "generate_uml_batch", "priority": 10 },
+    { "keyword": "multiple diagrams", "tool_name": "generate_uml_batch", "priority": 9 }
+  ],
+  "parameter_extractors": {},
+  "reminder_message": "UML-MCP tools: generate_uml renders one diagram, generate_uml_batch renders several, validate_uml checks syntax without rendering, list_diagram_types discovers supported types and formats. Pass diagram_type and code as structured arguments and send the diagram source through unmodified. PlantUML code must be wrapped in @startuml and @enduml. Render any returned URL as a clickable link, e.g. [View Diagram](URL)."
+}

--- a/tests/test_oi_manifest.py
+++ b/tests/test_oi_manifest.py
@@ -1,0 +1,100 @@
+"""Contract tests for oi-manifest.json.
+
+The manifest is consumed by an external agent runtime, so the failure mode is
+silent: a stale tool name or a duplicate keyword routes a user's request into
+nothing. These tests pin it to the live tool registry instead.
+"""
+
+import json
+import tomllib
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+MANIFEST_PATH = ROOT / "oi-manifest.json"
+
+
+@pytest.fixture(scope="module")
+def manifest() -> dict:
+    return json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+
+
+@pytest.fixture(scope="module")
+def registered_tool_names() -> set[str]:
+    from mcp_core.tools import diagram_tools  # noqa: F401  (populates the registry)
+    from mcp_core.tools.tool_decorator import get_tool_registry
+
+    return set(get_tool_registry())
+
+
+def test_manifest_is_valid_json_with_the_expected_shape(manifest: dict) -> None:
+    assert set(manifest) == {
+        "server_name",
+        "version",
+        "intents",
+        "parameter_extractors",
+        "reminder_message",
+    }
+    assert isinstance(manifest["intents"], list)
+    assert manifest["intents"]
+
+
+def test_manifest_targets_this_server(manifest: dict) -> None:
+    from mcp_core.core.config import MCPSettings
+
+    assert manifest["server_name"] == MCPSettings().server_name == "uml_mcp"
+
+
+def test_manifest_version_matches_project_version(manifest: dict) -> None:
+    from mcp_core.core.config import MCPSettings
+
+    pyproject = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+
+    assert manifest["version"] == pyproject["project"]["version"]
+    assert manifest["version"] == MCPSettings().version
+
+
+def test_every_intent_targets_a_registered_tool(
+    manifest: dict, registered_tool_names: set[str]
+) -> None:
+    targeted = {intent["tool_name"] for intent in manifest["intents"]}
+
+    assert targeted <= registered_tool_names
+    # Generation, validation, type discovery and batch generation must all be
+    # reachable; an unmapped tool is a tool OI OS can never call.
+    assert targeted == registered_tool_names
+
+
+def test_intent_keywords_are_unique(manifest: dict) -> None:
+    keywords = [intent["keyword"].strip().lower() for intent in manifest["intents"]]
+
+    assert all(keywords)
+    assert len(keywords) == len(set(keywords)), "duplicate keywords route ambiguously"
+
+
+def test_intent_priorities_are_sane(manifest: dict) -> None:
+    for intent in manifest["intents"]:
+        priority = intent["priority"]
+        assert isinstance(priority, int) and not isinstance(priority, bool)
+        assert 1 <= priority <= 10
+
+
+def test_parameter_extraction_is_left_to_the_mcp_client(manifest: dict) -> None:
+    """Deliberately empty.
+
+    The upstream OI OS fork extracted `code` with a rule that deletes the literal
+    words "generate", "create", "uml", "diagram" and "plantuml" from the request
+    before the tool sees it, which corrupts valid diagram source. Structured
+    argument construction stays the client's job.
+    """
+    assert manifest["parameter_extractors"] == {}
+
+
+def test_reminder_message_names_the_real_tools(
+    manifest: dict, registered_tool_names: set[str]
+) -> None:
+    reminder = manifest["reminder_message"]
+
+    assert all(name in reminder for name in registered_tool_names)
+    assert "@startuml" in reminder


### PR DESCRIPTION
## Why

[OI OS](https://github.com/OI-OS) routes natural-language requests to MCP tools through an intent manifest. `OI-OS/OI-uml-mcp` has one, but it targets an old server and ships changes we do not want. This adds a manifest retargeted to current `main`, with no fork and no new dependency.

## What

**`oi-manifest.json`** — `server_name: "uml_mcp"` (matches `MCPSettings.server_name`), version tracked against `pyproject.toml`, 14 unique keyword intents covering **all four** registered tools:

| Tool | Covers |
|---|---|
| `generate_uml` | generation — `generate uml`, `create diagram`, `class diagram`, `sequence diagram`, `mermaid diagram`, … |
| `validate_uml` | validation — `validate uml`, `check diagram syntax` |
| `list_diagram_types` | type discovery — `list diagram types`, `supported diagram types` |
| `generate_uml_batch` | batch generation — `generate diagrams batch`, `multiple diagrams` |

### `parameter_extractors` is deliberately `{}`

The upstream fork extracts the `code` argument with:

```json
"code": "remove:generate,create,uml,diagram,plantuml"
```

That deletes those literal words from the request before the tool ever sees it — so a diagram containing a class named `Diagram`, or a `@startuml`-wrapped body mentioning `create`, arrives corrupted. Regex cannot safely reconstruct diagram source. Building `diagram_type` and `code` stays the MCP client's job; the tools already validate their own inputs, and `validate_uml` reports syntax problems before you spend a render on them.

**Docs** — `docs/integrations/oi_os.md`, explicitly marked as a **community integration** (not officially supported by the OI OS project), plus a nav entry. It shows the manifest shape and explains the empty extractors.

**Tests** — `tests/test_oi_manifest.py` (8 tests): JSON validity, exact top-level shape, `server_name` == `MCPSettings().server_name`, version == `pyproject` == `MCPSettings`, keyword uniqueness (case-insensitive), priority range, that every intent targets a tool in `get_tool_registry()` **and** every registered tool has an intent, empty extractors, and that the reminder names the real tools.

## Verification

```
uv run pytest tests/test_oi_manifest.py           ->  8 passed
uv run pytest                                     ->  444 passed, 3 failed (pre-existing)
uv run ruff check / format --check <new files>    ->  clean
uv run ty check                                   ->  3 diagnostics, all pre-existing in mcp_core/tools/
MKDOCS_SOCIAL=false uv run mkdocs build --strict  ->  built
```

The 3 test failures are pre-existing on `main` and fixed by antoinebou12/uml-mcp#323.

## Not touched

No Python dependency changes — `OI-fastmcp` is not introduced. The PlantUML encoder in `tools/kroki/`, MCP tool schemas, `vercel.json` and `docker-compose.yml` are all untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)